### PR TITLE
Fix a minor error in DriversLicenseCalc script

### DIFF
--- a/siloCore/src/main/resources/de/tum/bgu/msm/models/DriversLicenseCalc
+++ b/siloCore/src/main/resources/de/tum/bgu/msm/models/DriversLicenseCalc
@@ -74,7 +74,7 @@ var calculateChangeDriversLicenseProbability = function(personType) {
     } else if (personType.name() == "WOMEN_AGE_100_PLUS"){
         return 0.00;
     }
-    return 0;
+    return 0.;
 }
 
 //Probability of having drivers license
@@ -152,5 +152,5 @@ var calculateCreateDriversLicenseProbability = function(personType) {
     } else if (personType.name() == "WOMEN_AGE_100_PLUS"){
         return 0.44;
     }
-    return 0;
+    return 0.;
 }


### PR DESCRIPTION
DriversLicenseCalc script: return Double (0.) instead of Integer (0) when none of the conditions is met.