### PR TITLE
msmLibraryDeployment

### DIFF
--- a/extensions/matsim2silo/pom.xml
+++ b/extensions/matsim2silo/pom.xml
@@ -11,6 +11,13 @@
 
     <artifactId>matsim2silo</artifactId>
 
+    <repositories>
+        <repository>
+            <id>matsim-snapshots</id>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.matsim.contrib</groupId>

--- a/extensions/matsim2silo/pom.xml
+++ b/extensions/matsim2silo/pom.xml
@@ -14,7 +14,7 @@
     <repositories>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/</url>
         </repository>
     </repositories>
 
@@ -23,16 +23,6 @@
             <groupId>org.matsim.contrib</groupId>
             <artifactId>dvrp</artifactId>
             <version>${matsimVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.media</groupId>
-                    <artifactId>jai_core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jgridshift</groupId>
-                    <artifactId>jgridshift</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/SiloMatsimUtils.java
+++ b/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/SiloMatsimUtils.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.matsim;
 
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.matrix.Matrix;
 
 import de.tum.bgu.msm.properties.Properties;
 import org.apache.log4j.Logger;

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -178,20 +178,23 @@
         </repository>
         <repository>
             <id>matsim</id>
-            <url>http://dl.bintray.com/matsim/matsim</url>
+            <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>
             <url>http://oss.jfrog.org/libs-snapshot</url>
         </repository>
         <repository>
-            <id>bintray-msmobility-maven</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/msmobility/maven</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>msm</id>
+            <url>https://dl.cloudsmith.io/public/msmobility/msm/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -181,6 +181,10 @@
             <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
         <repository>
+            <id>matsim-snapshots</id>
+            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+        </repository>
+        <repository>
             <id>msm</id>
             <url>https://dl.cloudsmith.io/public/msmobility/msm/maven/</url>
             <releases>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -182,7 +182,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>msm</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -182,7 +182,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>msm</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -182,7 +182,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/</url>
         </repository>
         <repository>
             <id>msm</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -168,7 +168,7 @@
             <!-- Geotools is not on Maven central -->
             <id>osgeo</id>
             <name>Geotools repository</name>
-            <url>http://download.osgeo.org/webdav/geotools</url>
+            <url>https://download.osgeo.org/webdav/geotools</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -179,10 +179,6 @@
         <repository>
             <id>matsim</id>
             <url>https://repo.matsim.org/repository/matsim</url>
-        </repository>
-        <repository>
-            <id>ojo-snapshots</id>
-            <url>http://oss.jfrog.org/libs-snapshot</url>
         </repository>
         <repository>
             <id>msm</id>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -195,6 +195,10 @@
             <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
         <repository>
+            <id>matsim-snapshots</id>
+            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+        </repository>
+        <repository>
             <id>ojo-snapshots</id>
             <url>http://oss.jfrog.org/libs-snapshot</url>
         </repository>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -110,27 +110,8 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- 	<plugin>
-                    <groupId>com.igormaznitsa</groupId>
-                    <artifactId>jute</artifactId>
-                    <version>1.1.1</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>jute</goal>
-                            </goals>
-                            <configuration>
-                                <verbose>true</verbose>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-             -->
+
             <plugin>
-                <!-- Usage (change version numbers, of course) mvn release:prepare -Darguments="-DskipTests
-            -Pbintray" -DreleaseVersion=0.7.1 -DdevelopmentVersion=0.7.2-SNAPSHOT -B
-            mvn release:perform -Darguments="-DskipTests -Pbintray" -DreleaseVersion=0.7.1
-            -DdevelopmentVersion=0.7.2-SNAPSHOT -B -->
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.1</version>
             </plugin>
@@ -181,9 +162,17 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>         
+            <id>msm</id>
+            <url>https://dl.cloudsmith.io/public/msmobility/msm/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
         <repository>
             <id>oss-jfrog-artifactory</id>
             <name>artifactory-snapshots</name>
@@ -208,11 +197,6 @@
         <repository>
             <id>ojo-snapshots</id>
             <url>http://oss.jfrog.org/libs-snapshot</url>
-        </repository>
-        <repository>
-            <id>bintray-msmobility-maven</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/msmobility/maven</url>
         </repository>
     </repositories>
 
@@ -255,14 +239,9 @@
             <version>1.17.1</version>
         </dependency>
         <dependency>
-            <groupId>common-base</groupId>
-            <artifactId>common-base</artifactId>
-            <version>0.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>sawdust</groupId>
-            <artifactId>sawdust</artifactId>
-            <version>1</version>
+            <groupId>de.tum.bgu.msm</groupId>
+            <artifactId>msm-commons</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>omx</groupId>
@@ -333,7 +312,7 @@
         <dependency>
             <groupId>com.github.msmobility</groupId>
             <artifactId>mito</artifactId>
-            <version>v28102020</version>
+            <version>master</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.media</groupId>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -330,12 +330,6 @@
             <version>2.8.5</version>
             <scope>compile</scope>
         </dependency>
-        <!-- need the jxl dependency for the pb.common calculator, as it is requested at runtime -->
-        <dependency>
-            <groupId>jexcelapi</groupId>
-            <artifactId>jxl</artifactId>
-            <version>2.6</version>
-        </dependency>
         <dependency>
             <groupId>com.github.msmobility</groupId>
             <artifactId>mito</artifactId>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -196,7 +196,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -196,7 +196,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>

--- a/siloCore/pom.xml
+++ b/siloCore/pom.xml
@@ -196,7 +196,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/SummarizeData.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/SummarizeData.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.data;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.development.Development;
 import de.tum.bgu.msm.data.dwelling.Dwelling;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/accessibility/CommutingTimeProbabilityImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/accessibility/CommutingTimeProbabilityImpl.java
@@ -2,9 +2,8 @@ package de.tum.bgu.msm.data.accessibility;
 
 import org.apache.log4j.Logger;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 
-import de.tum.bgu.msm.models.ModelUpdateListener;
 import de.tum.bgu.msm.properties.Properties;
 import de.tum.bgu.msm.utils.SiloUtil;
 

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/dwelling/RealEstateDataManagerImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/dwelling/RealEstateDataManagerImpl.java
@@ -2,7 +2,7 @@ package de.tum.bgu.msm.data.dwelling;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.development.Development;
 import de.tum.bgu.msm.data.development.DevelopmentImpl;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerImpl.java
@@ -19,7 +19,7 @@ package de.tum.bgu.msm.data.job;
 
 import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.accessibility.CommutingTimeProbability;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerWithCommuteModeChoice.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerWithCommuteModeChoice.java
@@ -19,7 +19,7 @@ package de.tum.bgu.msm.data.job;
 
 import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.accessibility.CommutingTimeProbability;

--- a/siloCore/src/main/java/de/tum/bgu/msm/io/input/DefaultGeoDataReader.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/io/input/DefaultGeoDataReader.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.io.input;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.geo.GeoData;

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionModelImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionModelImpl.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.models.realEstate.construction;
 
-import com.pb.common.util.IndexSort;
+import de.tum.bgu.msm.common.util.IndexSort;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.accessibility.Accessibility;

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionOverwriteImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionOverwriteImpl.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.models.realEstate.construction;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.Dwelling;
 import de.tum.bgu.msm.data.dwelling.DwellingFactory;

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/migration/InOutMigrationImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/migration/InOutMigrationImpl.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.models.relocation.migration;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.household.HouseholdDataManager;
 import de.tum.bgu.msm.data.household.Household;

--- a/siloCore/src/main/java/de/tum/bgu/msm/utils/CSVFileReader2.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/utils/CSVFileReader2.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.utils;
-import com.pb.common.datafile.DataTypes;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.DataTypes;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import org.apache.log4j.Logger;
 
 import java.io.*;

--- a/siloCore/src/main/java/de/tum/bgu/msm/utils/SiloUtil.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/utils/SiloUtil.java
@@ -1,9 +1,9 @@
 package de.tum.bgu.msm.utils;
 
-import com.pb.common.datafile.CSVFileWriter;
-import com.pb.common.datafile.TableDataFileReader;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.datafile.CSVFileWriter;
+import de.tum.bgu.msm.common.datafile.TableDataFileReader;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.container.ModelContainer;
 import de.tum.bgu.msm.data.SummarizeData;

--- a/siloCore/src/main/java/de/tum/bgu/msm/utils/TableDataFileReader2.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/utils/TableDataFileReader2.java
@@ -14,6 +14,9 @@ import com.pb.common.datafile.FileType;
 import com.pb.common.datafile.TableDataSet;
 */
 
+import de.tum.bgu.msm.common.datafile.FileType;
+import de.tum.bgu.msm.common.datafile.TableDataReader;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import com.pb.common.datafile.*;
 
 import java.io.File;

--- a/siloCore/src/main/java/de/tum/bgu/msm/utils/TableDataFileReader2.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/utils/TableDataFileReader2.java
@@ -8,16 +8,11 @@ package de.tum.bgu.msm.utils;
 // (powered by Fernflower decompiler)
 //
 
-/*
-import com.pb.common.datafile.*;
-import com.pb.common.datafile.FileType;
-import com.pb.common.datafile.TableDataSet;
-*/
+
 
 import de.tum.bgu.msm.common.datafile.FileType;
 import de.tum.bgu.msm.common.datafile.TableDataReader;
 import de.tum.bgu.msm.common.datafile.TableDataSet;
-import com.pb.common.datafile.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/DataSetSynPop.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/DataSetSynPop.java
@@ -3,8 +3,8 @@ package de.tum.bgu.msm.syntheticPopulationGenerator;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.data.dwelling.DwellingType;
 import org.apache.log4j.Logger;
 import org.opengis.feature.simple.SimpleFeature;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/austin/SyntheticPopUs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/austin/SyntheticPopUs.java
@@ -2,8 +2,8 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.austin;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.accessibility.AccessibilityImpl;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignJobs.java
@@ -1,14 +1,13 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.allocation;
 
 import com.google.common.math.LongMath;
-import com.pb.common.matrix.Matrix;
-import com.pb.common.matrix.RowVector;
+import de.tum.bgu.msm.common.matrix.Matrix;
+import de.tum.bgu.msm.common.matrix.RowVector;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;
 import de.tum.bgu.msm.data.household.HouseholdDataManager;
 import de.tum.bgu.msm.data.job.Job;
-import de.tum.bgu.msm.data.person.Gender;
 import de.tum.bgu.msm.data.person.Occupation;
 import de.tum.bgu.msm.data.person.Person;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignSchools.java
@@ -1,14 +1,13 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.allocation;
 
 import com.google.common.collect.Table;
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;
 import de.tum.bgu.msm.data.person.Gender;
 import de.tum.bgu.msm.data.person.Occupation;
 import de.tum.bgu.msm.data.person.Person;
-import de.tum.bgu.msm.data.person.PersonMuc;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.log4j.Logger;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/ValidateTripLengthDistribution.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/ValidateTripLengthDistribution.java
@@ -1,13 +1,12 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.allocation;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;
 import de.tum.bgu.msm.data.job.JobDataManager;
 import de.tum.bgu.msm.data.person.Occupation;
 import de.tum.bgu.msm.data.person.Person;
-import de.tum.bgu.msm.data.person.PersonMuc;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/CheckHouseholdRelationship.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/CheckHouseholdRelationship.java
@@ -1,11 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.preparation;
 
 
-import com.pb.common.datafile.TableDataSet;
-import de.tum.bgu.msm.data.household.Household;
-import de.tum.bgu.msm.data.household.HouseholdDataManager;
-import de.tum.bgu.msm.data.person.Person;
-import de.tum.bgu.msm.data.person.PersonRole;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.log4j.Logger;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/PrepareFrequencyMatrix.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/PrepareFrequencyMatrix.java
@@ -1,7 +1,6 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.preparation;
 
-import com.google.common.primitives.Ints;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadMicroData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadMicroData.java
@@ -1,20 +1,11 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.preparation;
 
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
-import de.tum.bgu.msm.syntheticPopulationGenerator.munich.preparation.MicroDataManager;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.log4j.Logger;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ReadMicroData {
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadZonalData.java
@@ -2,15 +2,11 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.preparation;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
-import de.tum.bgu.msm.data.dwelling.DefaultDwellingTypes;
-import de.tum.bgu.msm.data.dwelling.DwellingType;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
-import omx.OmxFile;
-import omx.OmxLookup;
 import org.apache.log4j.Logger;
 
 import java.io.BufferedReader;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/TranslateMicroDataToCode.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/TranslateMicroDataToCode.java
@@ -1,7 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.bangkok.preparation;
 
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCTrace.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCTrace.java
@@ -1,8 +1,8 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.capeTown;
 
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.*;
 import de.tum.bgu.msm.data.household.HouseholdDataManager;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/ExtractMicroDataJP.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/ExtractMicroDataJP.java
@@ -2,8 +2,8 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.kagawa;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.log4j.Logger;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/SyntheticPopJP.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/SyntheticPopJP.java
@@ -1,8 +1,8 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.kagawa;
 
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.DataBuilder;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.*;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/SyntheticPopUs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/SyntheticPopUs.java
@@ -2,8 +2,8 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.maryland;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.accessibility.Accessibility;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignJobs.java
@@ -1,8 +1,8 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.munich.allocation;
 
 import com.google.common.math.LongMath;
-import com.pb.common.matrix.Matrix;
-import com.pb.common.matrix.RowVector;
+import de.tum.bgu.msm.common.matrix.Matrix;
+import de.tum.bgu.msm.common.matrix.RowVector;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignSchools.java
@@ -1,7 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.munich.allocation;
 
 import com.google.common.collect.Table;
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/ValidateTripLengthDistribution.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/ValidateTripLengthDistribution.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.munich.allocation;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.Household;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/PrepareFrequencyMatrix.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/PrepareFrequencyMatrix.java
@@ -1,7 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.munich.preparation;
 
 import com.google.common.primitives.Ints;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.utils.SiloUtil;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadMicroData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadMicroData.java
@@ -3,7 +3,7 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.munich.preparation;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.utils.SiloUtil;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadZonalData.java
@@ -2,8 +2,8 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.munich.preparation;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.matrix.Matrix;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.matrix.Matrix;
 import de.tum.bgu.msm.data.dwelling.DefaultDwellingTypes;
 import de.tum.bgu.msm.data.dwelling.DwellingType;
 import de.tum.bgu.msm.utils.SiloUtil;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/Optimization.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/Optimization.java
@@ -2,7 +2,7 @@ package de.tum.bgu.msm.syntheticPopulationGenerator.optimizationIPU.optimization
 
 
 import com.google.common.primitives.Ints;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.syntheticPopulationGenerator.properties.PropertiesSynPop;
 import de.tum.bgu.msm.utils.SiloUtil;
 import de.tum.bgu.msm.syntheticPopulationGenerator.DataSetSynPop;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/perth/SyntheticPopPerth.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/perth/SyntheticPopPerth.java
@@ -1,7 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.perth;
 
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.dwelling.RealEstateDataManager;
 import de.tum.bgu.msm.data.household.HouseholdDataManager;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/properties/AbstractPropertiesSynPop.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/properties/AbstractPropertiesSynPop.java
@@ -1,12 +1,7 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.properties;
 
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
-import de.tum.bgu.msm.properties.PropertiesUtil;
-import de.tum.bgu.msm.utils.SiloUtil;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import org.apache.commons.math.distribution.GammaDistributionImpl;
-
-import java.util.ResourceBundle;
 
 public abstract class AbstractPropertiesSynPop {
     public boolean runSyntheticPopulation;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/properties/KagawaPropertiesSynPop.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/properties/KagawaPropertiesSynPop.java
@@ -1,7 +1,6 @@
 package de.tum.bgu.msm.syntheticPopulationGenerator.properties;
 
-import com.pb.common.datafile.TableDataSet;
-import com.pb.common.util.ResourceUtil;
+import de.tum.bgu.msm.common.util.ResourceUtil;
 import de.tum.bgu.msm.properties.PropertiesUtil;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.commons.math.distribution.GammaDistributionImpl;

--- a/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTest.java
+++ b/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTest.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.syntheticPopulation;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.utils.SiloUtil;
 import de.tum.bgu.msm.models.realEstate.construction.DefaultConstructionDemandStrategy;
 import org.junit.Before;

--- a/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTestOpt.java
+++ b/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTestOpt.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.syntheticPopulation;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.utils.SiloUtil;
 import de.tum.bgu.msm.models.realEstate.construction.DefaultConstructionDemandStrategy;
 import de.tum.bgu.msm.util.concurrent.ConcurrentExecutor;

--- a/useCases/bangkok/src/main/java/de/tum/bgu/msm/run/io/GeoDataReaderBangkok.java
+++ b/useCases/bangkok/src/main/java/de/tum/bgu/msm/run/io/GeoDataReaderBangkok.java
@@ -3,13 +3,11 @@ package de.tum.bgu.msm.run.io;
 import de.tum.bgu.msm.data.geo.ZoneImpl;
 import de.tum.bgu.msm.io.input.GeoDataReader;
 
-import com.pb.common.datafile.TableDataSet;
-import de.tum.bgu.msm.data.AreaTypes;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.geo.GeoData;
 import de.tum.bgu.msm.data.geo.RegionImpl;
-import de.tum.bgu.msm.io.input.GeoDataReader;
 import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.log4j.Logger;
 import org.matsim.core.utils.gis.ShapeFileReader;

--- a/useCases/capeTown/src/main/java/de/tum/bgu/msm/io/GeoDataReaderCapeTown.java
+++ b/useCases/capeTown/src/main/java/de/tum/bgu/msm/io/GeoDataReaderCapeTown.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.io;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.geo.GeoData;

--- a/useCases/kagawa/src/main/java/de/tum/bgu/msm/io/GeoDataReaderTak.java
+++ b/useCases/kagawa/src/main/java/de/tum/bgu/msm/io/GeoDataReaderTak.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.io;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.geo.GeoData;

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/data/DataContainerMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/data/DataContainerMstm.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.data;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.container.DefaultDataContainer;
 import de.tum.bgu.msm.data.accessibility.Accessibility;

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/io/GeoDataReaderMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/io/GeoDataReaderMstm.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.io;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.geo.GeoDataMstm;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionModelMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionModelMstm.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.models;
 
-import com.pb.common.util.IndexSort;
+import de.tum.bgu.msm.common.util.IndexSort;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.HouseholdDataManagerMstm;
 import de.tum.bgu.msm.data.Zone;

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMstm.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.models;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.HouseholdDataManagerMstm;
 import de.tum.bgu.msm.data.dwelling.Dwelling;

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/run/MstmMonitor.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/run/MstmMonitor.java
@@ -1,7 +1,7 @@
 package de.tum.bgu.msm.run;
 
 import com.google.common.collect.Multiset;
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Location;
 import de.tum.bgu.msm.data.Zone;

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/io/GeoDataReaderMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/io/GeoDataReaderMuc.java
@@ -1,6 +1,6 @@
 package de.tum.bgu.msm.io;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.AreaTypes;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;

--- a/useCases/perth/src/main/java/run/GeoDataReaderPerth.java
+++ b/useCases/perth/src/main/java/run/GeoDataReaderPerth.java
@@ -1,6 +1,6 @@
 package run;
 
-import com.pb.common.datafile.TableDataSet;
+import de.tum.bgu.msm.common.datafile.TableDataSet;
 import de.tum.bgu.msm.data.Region;
 import de.tum.bgu.msm.data.Zone;
 import de.tum.bgu.msm.data.geo.DefaultGeoData;

--- a/useCases/pom.xml
+++ b/useCases/pom.xml
@@ -189,6 +189,10 @@
             <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
         <repository>
+            <id>matsim-snapshots</id>
+            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+        </repository>
+        <repository>
             <id>ojo-snapshots</id>
             <url>http://oss.jfrog.org/libs-snapshot</url>
         </repository>

--- a/useCases/pom.xml
+++ b/useCases/pom.xml
@@ -186,16 +186,23 @@
         </repository>
         <repository>
             <id>matsim</id>
-            <url>http://dl.bintray.com/matsim/matsim</url>
+            <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>
             <url>http://oss.jfrog.org/libs-snapshot</url>
         </repository>
         <repository>
-            <id>bintray-msmobility-maven</id>
-            <name>bintray</name>
-            <url>http://dl.bintray.com/msmobility/maven</url>
+            <id>msm</id>
+            <url>https://dl.cloudsmith.io/public/msmobility/msm/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
         </repository>
         <repository>
             <id>jitpack.io</id>

--- a/useCases/pom.xml
+++ b/useCases/pom.xml
@@ -190,7 +190,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://repo.matsim.org/repository/matsim-snapshots/</url>
+            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>

--- a/useCases/pom.xml
+++ b/useCases/pom.xml
@@ -190,7 +190,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>http://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>

--- a/useCases/pom.xml
+++ b/useCases/pom.xml
@@ -190,7 +190,7 @@
         </repository>
         <repository>
             <id>matsim-snapshots</id>
-            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/org/matsim/</url>
+            <url>https://oss.jfrog.org/artifactory/simple/oss-snapshot-local/</url>
         </repository>
         <repository>
             <id>ojo-snapshots</id>


### PR DESCRIPTION
depend on mito and msm-commons now hosted on cloudsmith
(remove jitpack approach)
msm-commons replaces the pb-commons lib previously hosted on bintray
