### PR TITLE
reduce unwanted randomness

### DIFF
--- a/analysis/src/main/java/sdg/SDGCalculator.java
+++ b/analysis/src/main/java/sdg/SDGCalculator.java
@@ -31,13 +31,13 @@ public class SDGCalculator {
     private Collection<Dwelling> dwellings = new ArrayList<>();
     private Collection<Person> persons = new ArrayList<>();
     private RealEstateDataManager realEstateDataManager;
-    private Map<Integer, List<Household>> hhByZone = new HashMap<>();
-    private Map<Integer, List<Person>> ppByZone = new HashMap<>();
-    private Map<Integer, List<Dwelling>> ddByZone = new HashMap<>();
-    private Map<Integer, AnalyzedPerson> matsimPerson = new HashMap<>();
-    private Map<Integer, List<Trip>> commutingTripsByZone = new HashMap<>();
-    private Map<Integer, List<Trip>> schoolTripsByZone = new HashMap<>();
-    private Map<Integer, Map<Mode, List<Trip>>> ttByModeByZone = new HashMap<>();
+    private Map<Integer, List<Household>> hhByZone = new LinkedHashMap<>();
+    private Map<Integer, List<Person>> ppByZone = new LinkedHashMap<>();
+    private Map<Integer, List<Dwelling>> ddByZone = new LinkedHashMap<>();
+    private Map<Integer, AnalyzedPerson> matsimPerson = new LinkedHashMap<>();
+    private Map<Integer, List<Trip>> commutingTripsByZone = new LinkedHashMap<>();
+    private Map<Integer, List<Trip>> schoolTripsByZone = new LinkedHashMap<>();
+    private Map<Integer, Map<Mode, List<Trip>>> ttByModeByZone = new LinkedHashMap<>();
 
     public void setMatsimPerson(Map<Integer, AnalyzedPerson> matsimPerson) {
         this.matsimPerson = matsimPerson;

--- a/analysis/src/main/java/sdg/reader/CongestionEventHandler.java
+++ b/analysis/src/main/java/sdg/reader/CongestionEventHandler.java
@@ -13,6 +13,7 @@ import org.matsim.vehicles.Vehicle;
 import sdg.data.AnalyzedPerson;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CongestionEventHandler implements LinkEnterEventHandler, LinkLeaveEventHandler, VehicleLeavesTrafficEventHandler {
@@ -23,7 +24,7 @@ public class CongestionEventHandler implements LinkEnterEventHandler, LinkLeaveE
         return persons;
     }
 
-    private Map<Integer, AnalyzedPerson> persons = new HashMap<>();
+    private Map<Integer, AnalyzedPerson> persons = new LinkedHashMap<>();
 
     public CongestionEventHandler(Network network) {
         this.network = network;

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/dispersion/EmissionsOnLinkEventHandler.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/dispersion/EmissionsOnLinkEventHandler.java
@@ -11,6 +11,7 @@ import org.matsim.contrib.emissions.events.WarmEmissionEvent;
 import org.matsim.contrib.emissions.events.WarmEmissionEventHandler;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -41,7 +42,7 @@ class EmissionsOnLinkEventHandler implements WarmEmissionEventHandler, ColdEmiss
 
     @Override
     public void handleEvent(WarmEmissionEvent event) {
-        Map<Pollutant,Double> map = new HashMap<>() ;
+        Map<Pollutant,Double> map = new LinkedHashMap<>() ;
         for( Map.Entry<Pollutant, Double> entry : event.getWarmEmissions().entrySet() ){
             map.put( entry.getKey(), entry.getValue() ) ;
         }
@@ -59,10 +60,10 @@ class EmissionsOnLinkEventHandler implements WarmEmissionEventHandler, ColdEmiss
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> currentBin = timeBins.getTimeBin(time);
 
         if (!currentBin.hasValue()){
-            currentBin.setValue( new HashMap<>() );
+            currentBin.setValue( new LinkedHashMap<>() );
         }
         if (!currentBin.getValue().containsKey(linkId)){
-            currentBin.getValue().put( linkId, new EmissionsByPollutant( new HashMap<>( emissions ) ) );
+            currentBin.getValue().put( linkId, new EmissionsByPollutant( new LinkedHashMap<>( emissions ) ) );
         } else{
             currentBin.getValue().get( linkId ).addEmissions( emissions );
         }

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/emission/AnalyzedObject.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/emission/AnalyzedObject.java
@@ -4,6 +4,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.emissions.Pollutant;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AnalyzedObject<T> {
@@ -13,8 +14,8 @@ public class AnalyzedObject<T> {
 
     public AnalyzedObject(Id<T> id) {
         this.id = id;
-        this.warmEmissions = new HashMap<>();
-        this.coldEmissions = new HashMap<>();
+        this.warmEmissions = new LinkedHashMap<>();
+        this.coldEmissions = new LinkedHashMap<>();
     }
 
     public Map<Pollutant, Double>  getWarmEmissions() {

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/emission/LinkEmissionHandler.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/airPollutant/emission/LinkEmissionHandler.java
@@ -13,6 +13,7 @@ import org.matsim.contrib.emissions.events.WarmEmissionEventHandler;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class LinkEmissionHandler implements WarmEmissionEventHandler, ColdEmissionEventHandler {
@@ -26,8 +27,8 @@ public class LinkEmissionHandler implements WarmEmissionEventHandler, ColdEmissi
 
     public LinkEmissionHandler(Network network) {
         this.network = network;
-        emmisionsByLink = new HashMap<>();
-        emmisionsByVehicle = new HashMap<>();
+        emmisionsByLink = new LinkedHashMap<>();
+        emmisionsByVehicle = new LinkedHashMap<>();
     }
 
     @Override

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/data/ActivityLocation.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/data/ActivityLocation.java
@@ -5,6 +5,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.matsim.contrib.emissions.Pollutant;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ActivityLocation {
@@ -13,7 +14,7 @@ public class ActivityLocation {
 
     private final Coordinate coordinate;
 
-    private Map<Pollutant, OpenIntFloatHashMap> exposure2Pollutant2TimeBin = new HashMap<>();
+    private Map<Pollutant, OpenIntFloatHashMap> exposure2Pollutant2TimeBin = new LinkedHashMap<>();
 
     private OpenIntFloatHashMap noiseLevel2TimeBin = new OpenIntFloatHashMap();
 

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/data/LinkInfo.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/data/LinkInfo.java
@@ -7,15 +7,16 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.emissions.Pollutant;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class LinkInfo {
 
     private final Id<Link> linkId;
 
-    private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new HashMap<>();
+    private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new LinkedHashMap<>();
 
-    private Map<Pollutant, OpenIntFloatHashMap> exposure2Pollutant2TimeBin = new HashMap<>();
+    private Map<Pollutant, OpenIntFloatHashMap> exposure2Pollutant2TimeBin = new LinkedHashMap<>();
 
     private OpenIntFloatHashMap noiseLevel2TimeBin = new OpenIntFloatHashMap();
 

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/data/RelativeRisks.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/data/RelativeRisks.java
@@ -3,13 +3,14 @@ package de.tum.bgu.msm.health.data;
 import de.tum.bgu.msm.data.Mode;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 // Dose-response functions for health exposures (simple for now but will become more complex)
 public class RelativeRisks {
 
     public static Map<String, Float> calculate(PersonHealth personHealth) {
-        Map<String, Float> relativeRisks = new HashMap<>();
+        Map<String, Float> relativeRisks = new LinkedHashMap<>();
 
         relativeRisks.put("walk", (float) walk(personHealth.getWeeklyMarginalMetHours(Mode.walk)));
         relativeRisks.put("cycle", (float) bike(personHealth.getWeeklyMarginalMetHours(Mode.bicycle)));

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/data/Trip.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/data/Trip.java
@@ -5,6 +5,7 @@ import org.matsim.api.core.v01.Coord;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -44,12 +45,12 @@ public class Trip implements Id {
     private double matsimTravelDistance = 0.;
 
     private double marginalMetHours = 0.;
-    private Map<String, Float> travelRiskMap = new HashMap<>();
-    private Map<String, Float> travelExposureMap = new HashMap<>();
+    private Map<String, Float> travelRiskMap = new LinkedHashMap<>();
+    private Map<String, Float> travelExposureMap = new LinkedHashMap<>();
     private double travelNoiseExposure = 0.;
     private double travelNdviExposure = 0.;
 
-    private Map<String, Float> activityExposureMap = new HashMap<>();
+    private Map<String, Float> activityExposureMap = new LinkedHashMap<>();
     private double activityNoiseExposure = 0.;
     private double activityNdviExposure = 0.;
 

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentAgentInfo.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentAgentInfo.java
@@ -4,12 +4,13 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AccidentAgentInfo {
 
     private final Id<Person> personId;
-    private final Map<Id<Link>, Map<Integer, String>> linkId2time2mode = new HashMap<>();
+    private final Map<Id<Link>, Map<Integer, String>> linkId2time2mode = new LinkedHashMap<>();
     private double lightInjuryRisk;
     private double severeInjuryRisk;
 

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentLinkInfo.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentLinkInfo.java
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -35,19 +36,19 @@ public class AccidentLinkInfo {
 	
 	private final Id<Link> linkId;
 	
-	private final Map<Integer, TimeBinInfo> timeSpecificInfo = new HashMap<>();
+	private final Map<Integer, TimeBinInfo> timeSpecificInfo = new LinkedHashMap<>();
 
-//	private  Map<AccidentType, Map<Integer, Double>> lightCrashRateByAccidentTypeByTime = new HashMap<>();
+//	private  Map<AccidentType, Map<Integer, Double>> lightCrashRateByAccidentTypeByTime = new LinkedHashMap<>();
 //
-//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCrashRateByAccidentTypeByTime = new HashMap<>();
+//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCrashRateByAccidentTypeByTime = new LinkedHashMap<>();
 //
-//	private  Map<AccidentType, Map<Integer, Double>> lightCasualityRateByAccidentTypeByTime = new HashMap<>();
+//	private  Map<AccidentType, Map<Integer, Double>> lightCasualityRateByAccidentTypeByTime = new LinkedHashMap<>();
 //
-//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCasualityRateByAccidentTypeByTime = new HashMap<>();
+//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCasualityRateByAccidentTypeByTime = new LinkedHashMap<>();
 
-	private  Map<AccidentType, OpenIntFloatHashMap> lightCasualityExposureByAccidentTypeByTime = new HashMap<>();
+	private  Map<AccidentType, OpenIntFloatHashMap> lightCasualityExposureByAccidentTypeByTime = new LinkedHashMap<>();
 
-	private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new HashMap<>();
+	private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new LinkedHashMap<>();
 
 	public AccidentLinkInfo(Id<Link> linkId) {
 		this.linkId = linkId;

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateModelCoefficientReader.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateModelCoefficientReader.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AccidentRateModelCoefficientReader {
@@ -15,8 +16,8 @@ public class AccidentRateModelCoefficientReader {
     private AccidentType accidentType;
     private AccidentSeverity accidentSeverity;
     private String path;
-    private final Map<String, Double> coefficients = new HashMap<>();
-    private final Map<Integer, Double>  timeOfDayDistribution = new HashMap<>();
+    private final Map<String, Double> coefficients = new LinkedHashMap<>();
+    private final Map<Integer, Double>  timeOfDayDistribution = new LinkedHashMap<>();
 
     public AccidentRateModelCoefficientReader(AccidentType accidentType, AccidentSeverity accidentSeverity, String path) {
         this.accidentType = accidentType;

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentsContext.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentsContext.java
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -37,9 +38,9 @@ public final class AccidentsContext {
 	@Inject AccidentsContext(){}
 	// injected constructor is package-private so that nobody can instantiate this class directly
 	
-	private Map<Id<Link>, AccidentLinkInfo> linkId2info = new HashMap<>();
+	private Map<Id<Link>, AccidentLinkInfo> linkId2info = new LinkedHashMap<>();
 
-	private Map<Id<Person>, AccidentAgentInfo> personId2info = new HashMap<>();
+	private Map<Id<Person>, AccidentAgentInfo> personId2info = new LinkedHashMap<>();
 
 	public Map<Id<Link>, AccidentLinkInfo> getLinkId2info() {
 		return linkId2info;

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AnalysisEventHandler.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AnalysisEventHandler.java
@@ -33,10 +33,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.events.handler.EventHandler;
 import org.matsim.vehicles.Vehicle;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
 * @author ikaddoura
@@ -44,11 +41,11 @@ import java.util.Map;
 
 public class AnalysisEventHandler implements EventHandler, LinkLeaveEventHandler, PersonEntersVehicleEventHandler, PersonDepartureEventHandler {
 
-	private final Map<Id<Link>, Map<Integer, Integer>> linkId2time2leavingAgents = new HashMap<>();
-	private final Map<Id<Link>, Map<Integer, List<Id<Person>>>> linkId2time2personIds = new HashMap<>();
-	private final Map<Id<Vehicle>, Id<Person>> vehicleId2personId = new HashMap<>();
-	private final Map<Id<Link>, Map<String, Map<Integer, Integer>>> linkId2mode2time2leavingAgents = new HashMap<>();
-	private final Map<Id<Person>, String> personId2legMode = new HashMap<>();
+	private final Map<Id<Link>, Map<Integer, Integer>> linkId2time2leavingAgents = new LinkedHashMap<>();
+	private final Map<Id<Link>, Map<Integer, List<Id<Person>>>> linkId2time2personIds = new LinkedHashMap<>();
+	private final Map<Id<Vehicle>, Id<Person>> vehicleId2personId = new LinkedHashMap<>();
+	private final Map<Id<Link>, Map<String, Map<Integer, Integer>>> linkId2mode2time2leavingAgents = new LinkedHashMap<>();
+	private final Map<Id<Person>, String> personId2legMode = new LinkedHashMap<>();
 
 
 	@Inject AnalysisEventHandler(){}
@@ -89,13 +86,13 @@ public class AnalysisEventHandler implements EventHandler, LinkLeaveEventHandler
 						linkId2mode2time2leavingAgents.get(linkId).get(legMode).put(timeBinNr, 1);
 					}
 				} else {
-					Map<Integer,Integer> time2leavingAgents = new HashMap<>();
+					Map<Integer,Integer> time2leavingAgents = new LinkedHashMap<>();
 					time2leavingAgents.put(timeBinNr,1);
 					linkId2mode2time2leavingAgents.get(linkId).put(legMode, time2leavingAgents);
 				}
 			} else {
-				Map<String, Map<Integer,Integer>> mode2time2leavingAgents = new HashMap<>();
-				Map<Integer,Integer> time2leavingAgents = new HashMap<>();
+				Map<String, Map<Integer,Integer>> mode2time2leavingAgents = new LinkedHashMap<>();
+				Map<Integer,Integer> time2leavingAgents = new LinkedHashMap<>();
 				time2leavingAgents.put(timeBinNr,1);
 				mode2time2leavingAgents.put(legMode,time2leavingAgents);
 				linkId2mode2time2leavingAgents.put(linkId, mode2time2leavingAgents);
@@ -110,7 +107,7 @@ public class AnalysisEventHandler implements EventHandler, LinkLeaveEventHandler
 			if(personInfo.getLinkId2time2mode().get(linkId)!=null){
 				personInfo.getLinkId2time2mode().get(linkId).put(hour, legMode);
 			}else{
-				Map<Integer, String> time2Mode = new HashMap<>();
+				Map<Integer, String> time2Mode = new LinkedHashMap<>();
 				time2Mode.put(hour, legMode);
 				personInfo.getLinkId2time2mode().put(linkId, time2Mode);
 			}

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AnalysisEventHandlerOnline.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AnalysisEventHandlerOnline.java
@@ -34,6 +34,7 @@ import org.matsim.core.events.handler.EventHandler;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,11 +44,11 @@ import java.util.Map;
 
 public final class AnalysisEventHandlerOnline extends AnalysisEventHandler {
 
-	/*private final Map<Id<Link>, Map<Integer, Integer>> linkId2time2leavingAgents = new HashMap<>();
-	private final Map<Id<Link>, Map<Integer, List<Id<Person>>>> linkId2time2personIds = new HashMap<>();*/
-	private final Map<Id<Vehicle>, Id<Person>> vehicleId2personId = new HashMap<>();
-	private final Map<Id<Link>, Map<String, Map<Integer, Integer>>> linkId2mode2time2leavingAgents = new HashMap<>();
-	private final Map<Id<Person>, String> personId2legMode = new HashMap<>();
+	/*private final Map<Id<Link>, Map<Integer, Integer>> linkId2time2leavingAgents = new LinkedHashMap<>();
+	private final Map<Id<Link>, Map<Integer, List<Id<Person>>>> linkId2time2personIds = new LinkedHashMap<>();*/
+	private final Map<Id<Vehicle>, Id<Person>> vehicleId2personId = new LinkedHashMap<>();
+	private final Map<Id<Link>, Map<String, Map<Integer, Integer>>> linkId2mode2time2leavingAgents = new LinkedHashMap<>();
+	private final Map<Id<Person>, String> personId2legMode = new LinkedHashMap<>();
 
 
 	@Inject
@@ -89,13 +90,13 @@ public final class AnalysisEventHandlerOnline extends AnalysisEventHandler {
 						linkId2mode2time2leavingAgents.get(linkId).get(legMode).put(timeBinNr, 1);
 					}
 				} else {
-					Map<Integer,Integer> time2leavingAgents = new HashMap<>();
+					Map<Integer,Integer> time2leavingAgents = new LinkedHashMap<>();
 					time2leavingAgents.put(timeBinNr,1);
 					linkId2mode2time2leavingAgents.get(linkId).put(legMode, time2leavingAgents);
 				}
 			} else {
-				Map<String, Map<Integer,Integer>> mode2time2leavingAgents = new HashMap<>();
-				Map<Integer,Integer> time2leavingAgents = new HashMap<>();
+				Map<String, Map<Integer,Integer>> mode2time2leavingAgents = new LinkedHashMap<>();
+				Map<Integer,Integer> time2leavingAgents = new LinkedHashMap<>();
 				time2leavingAgents.put(timeBinNr,1);
 				mode2time2leavingAgents.put(legMode,time2leavingAgents);
 				linkId2mode2time2leavingAgents.put(linkId, mode2time2leavingAgents);

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/io/HealthTransitionTableReader.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/io/HealthTransitionTableReader.java
@@ -47,7 +47,7 @@ public class HealthTransitionTableReader {
 
                 String compositeKey = dataContainer.createTransitionLookupIndex(age,gender,location);
 
-                healthDiseaseData.computeIfAbsent(diseases, k -> new HashMap<>()).put(compositeKey, prob);
+                healthDiseaseData.computeIfAbsent(diseases, k -> new LinkedHashMap<>()).put(compositeKey, prob);
 
             }
         } catch (IOException e) {

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/io/SportPAmodelCoefficientReader.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/io/SportPAmodelCoefficientReader.java
@@ -16,9 +16,9 @@ public class SportPAmodelCoefficientReader {
     public Map<String,Map<String,Double>> readData(String fileName) {
         logger.info("Reading sport PA model coefficient from csv file");
 
-        Map<String,Map<String,Double>> coef = new HashMap<>();
-        coef.put("zero", new HashMap<>());
-        coef.put("linear", new HashMap<>());
+        Map<String,Map<String,Double>> coef = new LinkedHashMap<>();
+        coef.put("zero", new LinkedHashMap<>());
+        coef.put("linear", new LinkedHashMap<>());
 
 
         String recString = "";

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/io/TripReaderHealth.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/io/TripReaderHealth.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class TripReaderHealth {
@@ -22,7 +23,7 @@ public class TripReaderHealth {
 
     public Map<Integer, Trip> readData(String path) {
         logger.info("Reading mito trip micro data from csv file");
-        Map<Integer, Trip> mitoTrips = new HashMap<>();
+        Map<Integer, Trip> mitoTrips = new LinkedHashMap<>();
 
         String recString = "";
         int recCount = 0;

--- a/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/MatsimTravelTimesAndCosts.java
+++ b/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/MatsimTravelTimesAndCosts.java
@@ -49,7 +49,7 @@ public final class MatsimTravelTimesAndCosts implements TravelTimes {
 
     private MatsimData matsimData;
 
-    private final Map<String, IndexedDoubleMatrix2D> skimsByMode = new HashMap<>();
+    private final Map<String, IndexedDoubleMatrix2D> skimsByMode = new LinkedHashMap<>();
     private Map<Integer, Zone> zones;
 
     private TripRouter tripRouter;

--- a/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/SimpleMatsimCommuteModeChoice.java
+++ b/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/SimpleMatsimCommuteModeChoice.java
@@ -19,10 +19,7 @@ import de.tum.bgu.msm.models.modeChoice.CommuteModeChoiceMapping;
 import de.tum.bgu.msm.properties.Properties;
 import org.matsim.api.core.v01.TransportMode;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Copy of SimpleCommuteModeChoice, but with person in argument of travel time request
@@ -33,7 +30,7 @@ public class SimpleMatsimCommuteModeChoice implements CommuteModeChoice {
     private final CommutingTimeProbability commutingTimeProbability;
     private final JobDataManager jobDataManager;
     private final GeoData geoData;
-    private Random random;
+    private final Random random;
 
     public SimpleMatsimCommuteModeChoice(DataContainer dataContainer,
                                          Properties properties, Random random) {
@@ -50,7 +47,7 @@ public class SimpleMatsimCommuteModeChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
         for (Person pp : household.getPersons().values()) {
@@ -69,7 +66,7 @@ public class SimpleMatsimCommuteModeChoice implements CommuteModeChoice {
                     // TODO clean up the following line
                     int carMinutes = (int) ((MatsimTravelTimesAndCosts) travelTimes).getTravelTime(from, job, job.getStartTimeInSeconds().orElse((int) properties.transportModel.peakHour_s), TransportMode.car, pp);
                     double carUtility = commutingTimeProbability.getCommutingTimeProbability(carMinutes, TransportMode.car);
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, carUtility);
                     utilityByMode.put(TransportMode.pt, ptUtility);
                     commuteModesByPerson.put(pp.getId(), utilityByMode);
@@ -114,7 +111,7 @@ public class SimpleMatsimCommuteModeChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
 
@@ -134,7 +131,7 @@ public class SimpleMatsimCommuteModeChoice implements CommuteModeChoice {
                 } else {
                     int carMinutes = (int) travelTimes.getTravelTimeFromRegion(region, jobZone, job.getStartTimeInSeconds().orElse((int) properties.transportModel.peakHour_s), TransportMode.car);
                     double carUtility = commutingTimeProbability.getCommutingTimeProbability(carMinutes, TransportMode.car);
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, carUtility);
                     utilityByMode.put(TransportMode.pt, ptUtility);
                     commuteModesByPerson.put(pp.getId(), utilityByMode);

--- a/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/accessibility/AccessibilityModule.java
+++ b/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/accessibility/AccessibilityModule.java
@@ -26,6 +26,7 @@ import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.*;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -85,7 +86,7 @@ public class AccessibilityModule {
         acg.setMeasuringPointsFacilities(zoneRepresentativeCoords);
         //
         Map<Id<ActivityFacility>, Geometry> measurePointGeometryMap = new TreeMap<>();
-        Map<Integer, SimpleFeature> zoneFeatureMap = new HashMap<>();
+        Map<Integer, SimpleFeature> zoneFeatureMap = new LinkedHashMap<>();
         for (Zone zone : dataContainer.getGeoData().getZones().values()) {
             zoneFeatureMap.put(zone.getId(), zone.getZoneFeature());
         }

--- a/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/accessibility/MatsimAccessibility.java
+++ b/extensions/matsim2silo/src/main/java/de/tum/bgu/msm/matsim/accessibility/MatsimAccessibility.java
@@ -2,6 +2,7 @@ package de.tum.bgu.msm.matsim.accessibility;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import de.tum.bgu.msm.data.accessibility.Accessibility;
@@ -26,10 +27,10 @@ public class MatsimAccessibility implements Accessibility, FacilityDataExchangeI
 
 	private final GeoData geoData;
 
-	private Map<Tuple<ActivityFacility, Double>, Map<String,Double>> accessibilitiesMap = new HashMap<>();
+	private Map<Tuple<ActivityFacility, Double>, Map<String,Double>> accessibilitiesMap = new LinkedHashMap<>();
 
-	private Map<Id<ActivityFacility>, Double> autoAccessibilities = new HashMap<>();
-	private Map<Id<ActivityFacility>, Double> transitAccessibilities = new HashMap<>();
+	private Map<Id<ActivityFacility>, Double> autoAccessibilities = new LinkedHashMap<>();
+	private Map<Id<ActivityFacility>, Double> transitAccessibilities = new LinkedHashMap<>();
 	private IndexedDoubleMatrix1D regionalAccessibilities;
 	
 	public MatsimAccessibility(GeoData geoData) {
@@ -42,7 +43,7 @@ public class MatsimAccessibility implements Accessibility, FacilityDataExchangeI
 		if (timeOfDay == 8 * 60. * 60.) { // TODO Find better way for this check
 			Tuple<ActivityFacility, Double> key = new Tuple<>(measurePoint, timeOfDay);
 			if (!accessibilitiesMap.containsKey(key)) {
-				Map<String,Double> accessibilitiesByMode = new HashMap<>();
+				Map<String,Double> accessibilitiesByMode = new LinkedHashMap<>();
 				accessibilitiesMap.put(key, accessibilitiesByMode);
 			}
 			accessibilitiesMap.get(key).put(mode, accessibility);

--- a/extensions/mito2silo/src/main/java/de/tum/bgu/msm/mito/MitoMatsimScenarioAssembler.java
+++ b/extensions/mito2silo/src/main/java/de/tum/bgu/msm/mito/MitoMatsimScenarioAssembler.java
@@ -32,6 +32,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 import uk.cam.mrc.phm.MitoModelMCR;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -93,9 +94,9 @@ public class MitoMatsimScenarioAssembler implements MatsimScenarioAssembler {
         mito.run();
 
         logger.info("  Receiving demand from MITO");
-        Map<Day, Scenario> scenarios = new HashMap<>();
+        Map<Day, Scenario> scenarios = new LinkedHashMap<>();
 
-        Map<Day, Population> populationByDay = new HashMap();
+        Map<Day, Population> populationByDay = new LinkedHashMap();
 
         for(Person person: dataSet.getPopulation().getPersons().values()){
             Day day = Day.valueOf((String)person.getAttributes().getAttribute("day"));

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/SummarizeData.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/SummarizeData.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -192,7 +193,7 @@ public final class SummarizeData {
         int[] changeOfHh = new int[highestId + 1];
 
 
-        Map<Integer, int[]> hhByZone = new HashMap<>();
+        Map<Integer, int[]> hhByZone = new LinkedHashMap<>();
         RealEstateDataManager realEstateDataManager = dataContainer.getRealEstateDataManager();
         for (Household hh : dataContainer.getHouseholdDataManager().getHouseholds()) {
             int zone = -1;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/dwelling/RealEstateDataManagerImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/dwelling/RealEstateDataManagerImpl.java
@@ -45,11 +45,11 @@ public class RealEstateDataManagerImpl implements RealEstateDataManager {
     /**
      * Stores current shares of dwellings by quality levels. Updated once per year.
      */
-    private final Map<Integer, Double> updatedQualityShares = new HashMap<>();
+    private final Map<Integer, Double> updatedQualityShares = new LinkedHashMap<>();
     /**
      * Stores initial shares of dwellings by quality levels in the base year.
      */
-    private final Map<Integer, Double> initialQualityShares = new HashMap<>();
+    private final Map<Integer, Double> initialQualityShares = new LinkedHashMap<>();
 
     private int highestDwellingIdInUse;
     private static final Map<IncomeCategory, Map<Integer, Float>> ddPriceByIncomeCategory = new EnumMap<>(IncomeCategory.class);
@@ -263,7 +263,7 @@ public class RealEstateDataManagerImpl implements RealEstateDataManager {
         countOfHouseholdsByIncomeAndRentCategory.get(highestIncCat).add(RENT_CATEGORIES);  // make sure that most expensive category can be afforded by richest households
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
             float sum = countOfHouseholdsByIncomeAndRentCategory.get(incomeCategory).size();
-            Map<Integer, Float> shareOfRentsForThisIncCat = new HashMap<>();
+            Map<Integer, Float> shareOfRentsForThisIncCat = new LinkedHashMap<>();
             for (int rentCategory = 0; rentCategory <= RENT_CATEGORIES; rentCategory++) {
                 int thisRentAndIncomeCat = countOfHouseholdsByIncomeAndRentCategory.get(incomeCategory).count(rentCategory);
                 if (sum != 0) {
@@ -456,7 +456,7 @@ public class RealEstateDataManagerImpl implements RealEstateDataManager {
         TableDataSet developmentTable = SiloUtil.readCSVfile(baseDirectory + Properties.get().geo.landUseAndDevelopmentFile);
 
         int[] zoneIdData = developmentTable.getColumnAsInt("Zone");
-        Map<DwellingType, int[]> constraintData = new HashMap<>();
+        Map<DwellingType, int[]> constraintData = new LinkedHashMap<>();
         for (DwellingType dwellingType : dwellingTypes.getTypes()) {
             constraintData.put(dwellingType, developmentTable.getColumnAsInt(dwellingType.toString()));
         }
@@ -466,7 +466,7 @@ public class RealEstateDataManagerImpl implements RealEstateDataManager {
         for (int i = 0; i < zoneIdData.length; i++) {
             if(geoData.getZones().containsKey(zoneIdData[i])) {
 
-                Map<DwellingType, Boolean> constraints = new HashMap<>();
+                Map<DwellingType, Boolean> constraints = new LinkedHashMap<>();
                 for (DwellingType dwellingType : dwellingTypes.getTypes()) {
                     constraints.put(dwellingType, constraintData.get(dwellingType)[i] == 1);
                 }

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/geo/RegionImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/geo/RegionImpl.java
@@ -9,7 +9,7 @@ public class RegionImpl implements Region {
 
     private final Set<Zone> zones = new LinkedHashSet<>();
     private final int id;
-    private final Map<String, Object> attributes = new HashMap<>();
+    private final Map<String, Object> attributes = new LinkedHashMap<>();
 
     public RegionImpl(int id) {
         this.id = id;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/geo/ZoneImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/geo/ZoneImpl.java
@@ -14,6 +14,7 @@ import org.locationtech.jts.shape.random.RandomPointsBuilder;
 import org.matsim.core.utils.geometry.geotools.MGC;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 
@@ -28,7 +29,7 @@ public class ZoneImpl implements Zone {
 
     private Development development;
 
-    private final Map<String, Object> attributes = new HashMap<>();
+    private final Map<String, Object> attributes = new LinkedHashMap<>();
 
     public ZoneImpl(int id, float area_sqmi, Region region) {
         this.id = id;

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/household/HouseholdDataManagerImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/household/HouseholdDataManagerImpl.java
@@ -31,10 +31,7 @@ import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Greg Erhardt
@@ -59,7 +56,7 @@ public class HouseholdDataManagerImpl implements HouseholdDataManager {
 
     private float[][][] avgIncomeByGenderByAgeByOccupation;
 
-    private Map<Integer, Household> householdMementos = new HashMap<>();
+    private Map<Integer, Household> householdMementos = new LinkedHashMap<>();
 
     public HouseholdDataManagerImpl(HouseholdData householdData, DwellingData dwellingData,
                                     PersonFactory ppFactory, HouseholdFactory hhFactory,

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/household/HouseholdUtil.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/household/HouseholdUtil.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -201,7 +202,7 @@ public class HouseholdUtil {
     }
 
     public static Map<Integer, Integer> getPopulationByZoneAsMap(DataContainer dataContainer) {
-        Map<Integer, Integer> zonePopulationMap = new HashMap<>();
+        Map<Integer, Integer> zonePopulationMap = new LinkedHashMap<>();
         for (int zone : dataContainer.getGeoData().getZones().keySet()) {
             zonePopulationMap.put(zone, 0);
         }

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerImpl.java
@@ -76,7 +76,7 @@ public class JobDataManagerImpl implements UpdateListener, JobDataManager {
         this.jobData = jobData;
         this.travelTimes = travelTimes;
         this.commutingTimeProbability = commutingTimeProbability;
-        this.zonalJobDensity = new HashMap<>();
+        this.zonalJobDensity = new LinkedHashMap<>();
     }
 
     @Override
@@ -165,11 +165,11 @@ public class JobDataManagerImpl implements UpdateListener, JobDataManager {
 
     private void calculateEmploymentForecastWithRate() {
         int year = properties.main.startYear;
-        Map<Integer, Map<String, Float>> jobCountBaseyear = new HashMap<>();
+        Map<Integer, Map<String, Float>> jobCountBaseyear = new LinkedHashMap<>();
         jobsByYearByZoneByIndustry.put(year, jobCountBaseyear);
         //initialize maps with count = 0
         for (Zone zone : geoData.getZones().values()){
-            Map<String, Float> jobsInThisZone = new HashMap<>();
+            Map<String, Float> jobsInThisZone = new LinkedHashMap<>();
             jobCountBaseyear.put(zone.getZoneId(), jobsInThisZone);
             for (String jobType : JobType.getJobTypes()){
                 jobsInThisZone.put(jobType, 0.f);
@@ -185,10 +185,10 @@ public class JobDataManagerImpl implements UpdateListener, JobDataManager {
         //forecast the following years
         year++;
         while (year <= properties.main.endYear){
-            Map<Integer, Map<String, Float>> jobCountThisyear = new HashMap<>();
+            Map<Integer, Map<String, Float>> jobCountThisyear = new LinkedHashMap<>();
             jobsByYearByZoneByIndustry.put(year, jobCountThisyear);
             for (int zone : geoData.getZones().keySet()) {
-                Map<String, Float> jobCountThisZone = new HashMap<>();
+                Map<String, Float> jobCountThisZone = new LinkedHashMap<>();
                 for (String jobType : JobType.getJobTypes()){
                     jobCountThisZone.put(jobType, (float)(jobCountBaseyear.get(zone).get(jobType)*
                             Math.pow(1+properties.jobData.growthRateInPercentByJobType.get(jobType)/100,year - properties.main.startYear)));
@@ -252,7 +252,7 @@ public class JobDataManagerImpl implements UpdateListener, JobDataManager {
             for (int i = 0; i < yearsGiven.length - 1; i++) {
                 nextFixedYear = Integer.parseInt(yearsGiven[i + 1]);
                 while (interpolatedYear <= nextFixedYear) {
-                    Map<Integer, Map<String, Float>> jobsThisyear = new HashMap<>();
+                    Map<Integer, Map<String, Float>> jobsThisyear = new LinkedHashMap<>();
                     jobsByYearByZoneByIndustry.put(2000 + interpolatedYear, jobsThisyear);
                     final String forecastFileName = dir + properties.jobData.employmentForeCastFile + (2000 + interpolatedYear) + ".csv";
                     final PrintWriter pw = SiloUtil.openFileForSequentialWriting(forecastFileName, false);
@@ -262,7 +262,7 @@ public class JobDataManagerImpl implements UpdateListener, JobDataManager {
                     }
                     builder.append("\n");
                     for (int zone : geoData.getZones().keySet()) {
-                        Map<String, Float> jobsThisZone = new HashMap<>();
+                        Map<String, Float> jobsThisZone = new LinkedHashMap<>();
                         jobsThisyear.put(zone, jobsThisZone);
                         builder.append(zone);
                         for (int jobTp = 0; jobTp < JobType.getNumberOfJobTypes(); jobTp++) {

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerWithCommuteModeChoice.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobDataManagerWithCommuteModeChoice.java
@@ -81,7 +81,7 @@ public class JobDataManagerWithCommuteModeChoice implements UpdateListener, JobD
         this.travelTimes = travelTimes;
         this.commutingTimeProbability = commutingTimeProbability;
         this.commuteModeChoice = commuteModeChoice;
-        this.zonalJobDensity = new HashMap<>();
+        this.zonalJobDensity = new LinkedHashMap<>();
     }
 
     @Override
@@ -170,11 +170,11 @@ public class JobDataManagerWithCommuteModeChoice implements UpdateListener, JobD
 
     private void calculateEmploymentForecastWithRate() {
         int year = properties.main.startYear;
-        Map<Integer, Map<String, Float>> jobCountBaseyear = new HashMap<>();
+        Map<Integer, Map<String, Float>> jobCountBaseyear = new LinkedHashMap<>();
         jobsByYearByZoneByIndustry.put(year, jobCountBaseyear);
         //initialize maps with count = 0
         for (Zone zone : geoData.getZones().values()) {
-            Map<String, Float> jobsInThisZone = new HashMap<>();
+            Map<String, Float> jobsInThisZone = new LinkedHashMap<>();
             jobCountBaseyear.put(zone.getZoneId(), jobsInThisZone);
             for (String jobType : JobType.getJobTypes()) {
                 jobsInThisZone.put(jobType, 0.f);
@@ -190,10 +190,10 @@ public class JobDataManagerWithCommuteModeChoice implements UpdateListener, JobD
         //forecast the following years
         year++;
         while (year <= properties.main.endYear) {
-            Map<Integer, Map<String, Float>> jobCountThisyear = new HashMap<>();
+            Map<Integer, Map<String, Float>> jobCountThisyear = new LinkedHashMap<>();
             jobsByYearByZoneByIndustry.put(year, jobCountThisyear);
             for (int zone : geoData.getZones().keySet()) {
-                Map<String, Float> jobCountThisZone = new HashMap<>();
+                Map<String, Float> jobCountThisZone = new LinkedHashMap<>();
                 for (String jobType : JobType.getJobTypes()) {
                     jobCountThisZone.put(jobType, (float) (jobCountBaseyear.get(zone).get(jobType) *
                             Math.pow(1 + properties.jobData.growthRateInPercentByJobType.get(jobType) / 100, year - properties.main.startYear)));
@@ -257,7 +257,7 @@ public class JobDataManagerWithCommuteModeChoice implements UpdateListener, JobD
         for (int i = 0; i < yearsGiven.length - 1; i++) {
             nextFixedYear = Integer.parseInt(yearsGiven[i + 1]);
             while (interpolatedYear <= nextFixedYear) {
-                Map<Integer, Map<String, Float>> jobsThisyear = new HashMap<>();
+                Map<Integer, Map<String, Float>> jobsThisyear = new LinkedHashMap<>();
                 jobsByYearByZoneByIndustry.put(2000 + interpolatedYear, jobsThisyear);
                 final String forecastFileName = dir + properties.jobData.employmentForeCastFile + (2000 + interpolatedYear) + ".csv";
                 final PrintWriter pw = SiloUtil.openFileForSequentialWriting(forecastFileName, false);
@@ -267,7 +267,7 @@ public class JobDataManagerWithCommuteModeChoice implements UpdateListener, JobD
                 }
                 builder.append("\n");
                 for (int zone : geoData.getZones().keySet()) {
-                    Map<String, Float> jobsThisZone = new HashMap<>();
+                    Map<String, Float> jobsThisZone = new LinkedHashMap<>();
                     jobsThisyear.put(zone, jobsThisZone);
                     builder.append(zone);
                     for (int jobTp = 0; jobTp < JobType.getNumberOfJobTypes(); jobTp++) {

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobType.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/job/JobType.java
@@ -2,6 +2,7 @@ package de.tum.bgu.msm.data.job;
 
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 /**
  * Job types that are distinguished in the model
@@ -18,7 +19,7 @@ public class JobType {
 
     public JobType(String[] jobTypesArg) {
         jobTypes = jobTypesArg;
-        ordinal = new HashMap<>();
+        ordinal = new LinkedHashMap<>();
         for (int i = 0; i < jobTypes.length; i++) {
             ordinal.put(jobTypes[i], i);
         }

--- a/siloCore/src/main/java/de/tum/bgu/msm/data/vehicle/VehicleUtil.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/data/vehicle/VehicleUtil.java
@@ -5,11 +5,12 @@ import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.commons.math3.distribution.NormalDistribution;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class VehicleUtil {
 
-    static Map<Integer, Double> probabilities = new HashMap<>();
+    static Map<Integer, Double> probabilities = new LinkedHashMap<>();
 
     public static void initializeVehicleUtils(){
         final NormalDistribution normalDistribution = new NormalDistribution(4.29, 8.15);

--- a/siloCore/src/main/java/de/tum/bgu/msm/io/input/CoefficientsReader.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/io/input/CoefficientsReader.java
@@ -5,12 +5,13 @@ import de.tum.bgu.msm.util.MitoUtil;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CoefficientsReader extends AbstractCsvReader{
 
 
-        private final Map<String, Double> coefficients = new HashMap<>();
+        private final Map<String, Double> coefficients = new LinkedHashMap<>();
         private final String id;
 
         private int variableIndex;

--- a/siloCore/src/main/java/de/tum/bgu/msm/io/output/ModalSharesResultMonitor.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/io/output/ModalSharesResultMonitor.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,13 +73,13 @@ public class ModalSharesResultMonitor implements ResultsMonitor {
 
         logger.info("Printing out modal shares by zone");
 
-        Map<Integer, Integer> tripsByCar = new HashMap<>();
-        Map<Integer, Integer> tripsByPt = new HashMap<>();
-        Map<Integer, Integer>tripsByOther = new HashMap<>();
-        Map<Integer, Double> timeByCar = new HashMap<>();
-        Map<Integer, Double> timeByPt = new HashMap<>();
-        Map<Integer, Double> timeByOther = new HashMap<>();
-        Map<Integer, Integer> doNotTravel = new HashMap<>();
+        Map<Integer, Integer> tripsByCar = new LinkedHashMap<>();
+        Map<Integer, Integer> tripsByPt = new LinkedHashMap<>();
+        Map<Integer, Integer>tripsByOther = new LinkedHashMap<>();
+        Map<Integer, Double> timeByCar = new LinkedHashMap<>();
+        Map<Integer, Double> timeByPt = new LinkedHashMap<>();
+        Map<Integer, Double> timeByOther = new LinkedHashMap<>();
+        Map<Integer, Integer> doNotTravel = new LinkedHashMap<>();
 
         AtomicInteger car = new AtomicInteger();
         AtomicInteger pt = new AtomicInteger();

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/jobmography/JobMarketUpdateImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/jobmography/JobMarketUpdateImpl.java
@@ -67,7 +67,7 @@ public class JobMarketUpdateImpl extends AbstractModel implements JobMarketUpdat
         //TableDataSet forecast = SiloUtil.readCSVfile(forecastFileName);
 
 
-        Map<String, List<Integer>> jobsAvailableForRemoval = new HashMap<>();
+        Map<String, List<Integer>> jobsAvailableForRemoval = new LinkedHashMap<>();
         for (Job jj : jobDataManager.getJobs()) {
             String token = jj.getType() + "." + jj.getZoneId() + "." + (jj.getWorkerId() == -1);
             if (jobsAvailableForRemoval.containsKey(token)) {

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/modeChoice/SimpleCommuteModeChoice.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/modeChoice/SimpleCommuteModeChoice.java
@@ -17,10 +17,7 @@ import de.tum.bgu.msm.data.vehicle.VehicleType;
 import de.tum.bgu.msm.properties.Properties;
 import org.matsim.api.core.v01.TransportMode;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
+import java.util.*;
 
 public class SimpleCommuteModeChoice implements CommuteModeChoice {
 
@@ -63,7 +60,7 @@ public class SimpleCommuteModeChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
         for (Person pp : household.getPersons().values()) {
@@ -90,7 +87,7 @@ public class SimpleCommuteModeChoice implements CommuteModeChoice {
                     ptUtility = Math.exp(ptUtility);
                     carUtility = Math.exp(carUtility);
 
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, Math.pow(commutingTimeProbabilityCar, B_EXP_HOUSING_UTILITY));
                     utilityByMode.put(TransportMode.pt, Math.pow(commutingTimeProbabilityPt, B_EXP_HOUSING_UTILITY));
                     commuteModesByPerson.put(pp.getId(), utilityByMode);
@@ -138,7 +135,7 @@ public class SimpleCommuteModeChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
 
@@ -163,7 +160,7 @@ public class SimpleCommuteModeChoice implements CommuteModeChoice {
                             job.getStartTimeInSeconds().orElse((int) properties.transportModel.peakHour_s), TransportMode.car);
                     double commutingTimeProbabilityCar = this.commutingTimeProbability.getCommutingTimeProbability(carMinutes, TransportMode.car);
                     double carUtility = B_TIME * commutingTimeProbabilityCar;
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, Math.pow(commutingTimeProbabilityCar, B_EXP_HOUSING_UTILITY));
                     utilityByMode.put(TransportMode.pt, Math.pow(commutingTimeProbabilityPt, B_EXP_HOUSING_UTILITY));
                     commuteModesByPerson.put(pp.getId(), utilityByMode);

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionOverwriteImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/construction/ConstructionOverwriteImpl.java
@@ -80,7 +80,7 @@ public class ConstructionOverwriteImpl extends AbstractModel implements Construc
 
         String fileName = properties.main.baseDirectory + properties.realEstate.constructionOverwriteDwellingFile;
         TableDataSet overwrite = SiloUtil.readCSVfile(fileName);
-        plannedDwellings = new HashMap<>();
+        plannedDwellings = new LinkedHashMap<>();
 
         for (int row = 1; row <= overwrite.getRowCount(); row++) {
             int year = (int) overwrite.getValueAt(row, "year");

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/pricing/PricingModelImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/realEstate/pricing/PricingModelImpl.java
@@ -11,10 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 /**
  * Updates prices of dwellings based on current demand
@@ -49,9 +46,9 @@ public final class PricingModelImpl extends AbstractModel implements PricingMode
     @Override
     public void prepareYear(int year) {
 
-        changeRateDistribution = new HashMap<>();
+        changeRateDistribution = new LinkedHashMap<>();
         for (DwellingType type : dataContainer.getRealEstateDataManager().getDwellingTypes().getTypes()) {
-            changeRateDistribution.put(type, new HashMap<>());
+            changeRateDistribution.put(type, new LinkedHashMap<>());
         }
     }
 
@@ -78,7 +75,7 @@ public final class PricingModelImpl extends AbstractModel implements PricingMode
         // get vacancy rate
         double[][] vacRate = dataContainer.getRealEstateDataManager().getVacancyRateByTypeAndRegion();
         List<DwellingType> dwellingTypes = dataContainer.getRealEstateDataManager().getDwellingTypes().getTypes();
-//        HashMap<String, Integer> priceChange = new HashMap<>();
+//        HashMap<String, Integer> priceChange = new LinkedHashMap<>();
 
         double[] globalVacRate = dataContainer.getRealEstateDataManager().getAverageVacancyByDwellingType();
         int[] cnt = new int[dwellingTypes.size()];

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/CarAndTransitHousingStrategyImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/CarAndTransitHousingStrategyImpl.java
@@ -27,6 +27,7 @@ import org.matsim.api.core.v01.TransportMode;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
@@ -233,7 +234,7 @@ public class CarAndTransitHousingStrategyImpl implements HousingStrategy {
         logger.info("Calculating regional utilities");
         final Map<Integer, Double> rentsByRegion = dataContainer.getRealEstateDataManager().calculateRegionalPrices();
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
-            Map<Integer, Double> utilityByRegion = new HashMap<>();
+            Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
             for (Region region : geoData.getRegions().values()) {
                 final int averageRegionalRent = rentsByRegion.get(region.getId()).intValue();
                 final float regAcc = (float) convertAccessToUtility(accessibility.getRegionalAccessibility(region));

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/CarOnlyHousingStrategyImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/CarOnlyHousingStrategyImpl.java
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.TransportMode;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
@@ -206,7 +207,7 @@ public class CarOnlyHousingStrategyImpl implements HousingStrategy {
         logger.info("Calculating regional utilities");
         final Map<Integer, Double> rentsByRegion = dataContainer.getRealEstateDataManager().calculateRegionalPrices();
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
-            Map<Integer, Double> utilityByRegion = new HashMap<>();
+            Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
             for (Region region : geoData.getRegions().values()) {
                 final int averageRegionalRent = rentsByRegion.get(region.getId()).intValue();
                 final float regAcc = (float) convertAccessToUtility(accessibility.getRegionalAccessibility(region));

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
@@ -51,7 +51,8 @@ public class MovesModelImpl extends AbstractModel implements MovesModel {
     private final MovesStrategy movesStrategy;
     private final HousingStrategy housingStrategy;
 
-    private final boolean threaded;
+    private final boolean threaded = false;
+    // switching this off since we are searching for randomness in regression tests
 
     private final Map<HouseholdType, Double> averageHousingSatisfaction = new ConcurrentHashMap<>();
     private final Map<Integer, Double> satisfactionByHousehold = new ConcurrentHashMap<>();
@@ -72,7 +73,7 @@ public class MovesModelImpl extends AbstractModel implements MovesModel {
 //        }
         this.movesStrategy = movesStrategy;
         this.housingStrategy = housingStrategy;
-        this.threaded = properties.transportModel.travelTimeImplIdentifier == TransportModelPropertiesModule.TravelTimeImplIdentifier.MATSIM;
+//        this.threaded = properties.transportModel.travelTimeImplIdentifier == TransportModelPropertiesModule.TravelTimeImplIdentifier.MATSIM;
     }
 
     @Override

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
@@ -43,7 +43,7 @@ public class MovesModelImpl extends AbstractModel implements MovesModel {
 
 //    public static BufferedWriter fileWriter;
 
-    public static boolean track = false;
+    public boolean track = false;
 
     protected final static Logger logger = LogManager.getLogger(MovesModelImpl.class);
     private static final int MAX_NUMBER_DWELLINGS = 20;

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/MovesModelImpl.java
@@ -55,8 +55,8 @@ public class MovesModelImpl extends AbstractModel implements MovesModel {
 
     private final Map<HouseholdType, Double> averageHousingSatisfaction = new ConcurrentHashMap<>();
     private final Map<Integer, Double> satisfactionByHousehold = new ConcurrentHashMap<>();
-    private final Map<Integer, Integer> householdsByZone = new HashMap<>();
-    private final Map<Integer, Double > sumOfSatisfactionsByZone = new HashMap<>();
+    private final Map<Integer, Integer> householdsByZone = new LinkedHashMap<>();
+    private final Map<Integer, Double > sumOfSatisfactionsByZone = new LinkedHashMap<>();
     private YearByYearCsvModelTracker relocationTracker;
 
 

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/SimpleCommuteHousingStrategyWithoutCarOwnership.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/SimpleCommuteHousingStrategyWithoutCarOwnership.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
@@ -218,7 +219,7 @@ public class SimpleCommuteHousingStrategyWithoutCarOwnership implements HousingS
         logger.info("Calculating regional utilities");
         final Map<Integer, Double> rentsByRegion = dataContainer.getRealEstateDataManager().calculateRegionalPrices();
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
-            Map<Integer, Double> utilityByRegion = new HashMap<>();
+            Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
             for (Region region : geoData.getRegions().values()) {
                 final int averageRegionalRent = rentsByRegion.get(region.getId()).intValue();
                 final float regAcc = (float) convertAccessToUtility(accessibility.getRegionalAccessibility(region));

--- a/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/SimpleCommuteModeChoiceHousingStrategyImpl.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/models/relocation/moves/SimpleCommuteModeChoiceHousingStrategyImpl.java
@@ -23,10 +23,7 @@ import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
 
@@ -219,7 +216,7 @@ public class SimpleCommuteModeChoiceHousingStrategyImpl implements HousingStrate
         logger.info("Calculating regional utilities");
         final Map<Integer, Double> rentsByRegion = dataContainer.getRealEstateDataManager().calculateRegionalPrices();
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
-            Map<Integer, Double> utilityByRegion = new HashMap<>();
+            Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
             for (Region region : geoData.getRegions().values()) {
                 final int averageRegionalRent = rentsByRegion.get(region.getId()).intValue();
                 final float regAcc = (float) convertAccessToUtility(accessibility.getRegionalAccessibility(region));

--- a/siloCore/src/main/java/de/tum/bgu/msm/properties/PropertiesUtil.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/properties/PropertiesUtil.java
@@ -15,7 +15,7 @@ public class PropertiesUtil {
 
     private final static String FORMAT = "%-60s%s";
     private final static String FORMAT_DEFAULT = "%-80s%s";
-    private final static Map<Integer, String> propertiesInUse = new HashMap<>();
+    private final static Map<Integer, String> propertiesInUse = new LinkedHashMap<>();
     private final static Logger logger = LogManager.getLogger(PropertiesUtil.class);
 
     public static int getIntProperty(ResourceBundle bundle, String key, int defaultValue) {

--- a/siloCore/src/main/java/de/tum/bgu/msm/properties/modules/JobDataProperties.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/properties/modules/JobDataProperties.java
@@ -3,6 +3,7 @@ package de.tum.bgu.msm.properties.modules;
 import de.tum.bgu.msm.properties.PropertiesUtil;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -15,7 +16,7 @@ public final class JobDataProperties {
     public final JobForecastMethod jobForecastMethod;
     public final String jobControlTotalsFileName;
     public final String employmentForeCastFile;
-    public final Map<String,Double> growthRateInPercentByJobType = new HashMap<>();
+    public final Map<String,Double> growthRateInPercentByJobType = new LinkedHashMap<>();
     public final String jobStartTimeDistributionFile;
     public final String jobDurationDistributionFile;
 

--- a/siloCore/src/main/java/de/tum/bgu/msm/utils/DeferredAcceptanceMatching.java
+++ b/siloCore/src/main/java/de/tum/bgu/msm/utils/DeferredAcceptanceMatching.java
@@ -19,8 +19,8 @@ public class DeferredAcceptanceMatching {
                                                                  Collection<Integer> set2,
                                                                  DoubleMatrix2D preferences) {
 
-        Map<Integer, Integer> matches = new HashMap<>();
-        Map<Integer, List<Tuple<Integer, Double>>> offers = new HashMap<>();
+        Map<Integer, Integer> matches = new LinkedHashMap<>();
+        Map<Integer, List<Tuple<Integer, Double>>> offers = new LinkedHashMap<>();
         for (int id: set) {
             double[] max = preferences.viewRow(id).getMaxLocation();
             if (offers.containsKey((int) max[1])) {

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/CoefficientsReader.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/CoefficientsReader.java
@@ -6,12 +6,13 @@ import de.tum.bgu.msm.util.MitoUtil;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CoefficientsReader extends AbstractCsvReader {
 
 
-    private final Map<String, Double> coefficients = new HashMap<>();
+    private final Map<String, Double> coefficients = new LinkedHashMap<>();
     private final String id;
 
     private int variableIndex;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/austin/SyntheticPopUs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/austin/SyntheticPopUs.java
@@ -153,7 +153,7 @@ public class SyntheticPopUs implements SyntheticPopI {
     private void identifyUniquePUMAzones() {
         // walk through list of zones and collect unique PUMA zone IDs within the study area
 
-        tazByPuma = new HashMap<>();
+        tazByPuma = new LinkedHashMap<>();
         ArrayList<Integer> alHomePuma = new ArrayList<>();
         ArrayList<Integer> alWorkPuma = new ArrayList<>();
         for (Zone zone: geoData.getZones().values()) {
@@ -184,7 +184,7 @@ public class SyntheticPopUs implements SyntheticPopI {
 
         logger.info("  Reading control total data for households and dwellings");
 //        TableDataSet pop = SiloUtil.readCSVfile(Properties.get().main.baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_HOUSEHOLD_CONTROL_TOTAL));
-        householdTarget = new HashMap<>();
+        householdTarget = new LinkedHashMap<>();
 //        for (int row = 1; row <= pop.getRowCount(); row++) {
 //            String fips = String.valueOf(pop.getValueAt(row, "Fips"));
 //            // note: doesn't make much sense to store these data in a HashMap. It's legacy code.
@@ -206,7 +206,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // jobInventory by [industry][taz]
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         float[][] jobInventory = new float[JobType.getNumberOfJobTypes()][highestZoneId + 1];
-        tazByWorkZonePuma = new HashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
+        tazByWorkZonePuma = new LinkedHashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
 
         // read employment data
         // For reasons that are not explained in the documentation, some of the PUMA work zones were aggregated to the
@@ -250,7 +250,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // populate HashMap with Jobs by zone
 
         logger.info("  Identifying vacant jobs by zone");
-        vacantJobsByZone = new HashMap<>();
+        vacantJobsByZone = new LinkedHashMap<>();
         Collection<Job> jobs = jobData.getJobs();
         for (Job jj: jobs) {
             if (jj.getWorkerId() == -1) {
@@ -285,11 +285,11 @@ public class SyntheticPopUs implements SyntheticPopI {
 
         String[] states = {"tx"};
 
-        jobErrorCounter = new HashMap<>();
+        jobErrorCounter = new LinkedHashMap<>();
 
         for (String state : states) {
-            Map<Integer, Integer> relationsHipsByPerson = new HashMap<>();
-            Map<Long, List<Household>> households = new HashMap<>();
+            Map<Integer, Integer> relationsHipsByPerson = new LinkedHashMap<>();
+            Map<Long, List<Household>> households = new LinkedHashMap<>();
 
             String pumsHhFileName = baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_PUMS_FILES) +
                     "ss17h" + state + ".csv";
@@ -790,7 +790,7 @@ public class SyntheticPopUs implements SyntheticPopI {
             return -2;  // person does work in puma zone outside of study area
         }
 
-        Map<Zone, Double> zoneProbabilities = new HashMap<>();
+        Map<Zone, Double> zoneProbabilities = new LinkedHashMap<>();
         for (Zone zone: geoData.getZones().values()) {
             if (vacantJobsByZone.containsKey(zone.getZoneId())) {
                 int numberOfJobsInThisZone = vacantJobsByZone.get(zone.getZoneId()).length;
@@ -951,7 +951,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // select number of cars for every household
         dataContainer.getJobDataManager().setup();
         MaryLandUpdateCarOwnershipModel ao = new MaryLandUpdateCarOwnershipModel(dataContainer, accessibility, Properties.get(), SiloUtil.provideNewRandom());   // calculate auto-ownership probabilities
-        Map<Integer, int[]> households = new HashMap<>();
+        Map<Integer, int[]> households = new LinkedHashMap<>();
         for (Household hh: householdData.getHouseholds()) {
             households.put(hh.getId(), null);
         }
@@ -964,7 +964,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         logger.info("  Adding empty dwellings to match vacancy rate");
 
         List<DwellingType> dwellingTypes = realEstateData.getDwellingTypes().getTypes();
-        HashMap<String, ArrayList<Integer>> ddPointer = new HashMap<>();
+        HashMap<String, ArrayList<Integer>> ddPointer = new LinkedHashMap<>();
         // summarize vacancy
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         int[][][] ddCount = new int [highestZoneId + 1][DefaultDwellingTypes.DefaultDwellingTypeImpl.values().length][2];

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/Allocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/Allocation.java
@@ -58,7 +58,7 @@ public class Allocation extends ModuleSynPop{
     }
 
     public void generateHouseholdsPersonsDwellings(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new GenerateHouseholdsPersonsDwellings(dataContainer, dataSetSynPop, educationalLevel).run();
     }
 
@@ -77,7 +77,7 @@ public class Allocation extends ModuleSynPop{
     public void generateAutos() {new CarOwnership(dataContainer).run();}
 
     public void readPopulation(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new ReadPopulation(dataContainer, educationalLevel).run();
     }
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignJobs.java
@@ -138,18 +138,18 @@ public class AssignJobs {
         Collection<Job> jobs = dataContainer.getJobDataManager().getJobs();
 
         jobStringTypes = PropertiesSynPop.get().main.jobStringType;
-        jobIntTypes = new HashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }
         tazIds = dataSetSynPop.getTazs().stream().mapToInt(i -> i).toArray();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
-        jobIntTypes = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/AssignSchools.java
@@ -95,7 +95,7 @@ public class AssignSchools {
 
         int schooltaz = -2;
         if (numberOfVacantPlacesByType.get(3) > 0) {
-            Map<Integer, Float> probability = new HashMap<>();
+            Map<Integer, Float> probability = new LinkedHashMap<>();
             Iterator<Integer> iterator = schoolCapacityMap.get(3).keySet().iterator();
             while (iterator.hasNext()) {
                 Integer zone = iterator.next();
@@ -159,8 +159,8 @@ public class AssignSchools {
 
     private void initializeSchoolCapacity(){
 
-        schoolCapacityMap = new HashMap<>();
-        numberOfVacantPlacesByType = new HashMap<>();
+        schoolCapacityMap = new LinkedHashMap<>();
+        numberOfVacantPlacesByType = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = dataSetSynPop.getSchoolCapacity();
         Iterator<Integer> iteratorRow = schoolCapacity.rowKeySet().iterator();
         while (iteratorRow.hasNext()){
@@ -170,7 +170,7 @@ public class AssignSchools {
                 int schoolType = iteratorCol.next();
                 int places = schoolCapacity.get(zone, schoolType);
                 if (places > 0) {
-                    Map<Integer, Integer> prevPlaces = new HashMap<>();
+                    Map<Integer, Integer> prevPlaces = new LinkedHashMap<>();
                     if (schoolCapacityMap.get(schoolType)!= null) {
                         prevPlaces = schoolCapacityMap.get(schoolType);
                     }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateHouseholdsPersonsDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateHouseholdsPersonsDwellings.java
@@ -183,9 +183,9 @@ public class GenerateHouseholdsPersonsDwellings {
         double averageIncomeByZoneCensus = PropertiesSynPop.get().main.cellsMatrix.getIndexedValueAt(municipality, "income");
         double averageIncomeZone = incomeByMunicipality / personCounterByMunicipality;
         double incomeMultiplier = averageIncomeByZoneCensus / averageIncomeZone;
-        Map<Integer, Household> householdMap = new HashMap<>();
-        Map<Integer, Dwelling> dwellingMap = new HashMap<>();
-        Map<Integer, Person> personMap = new HashMap<>();
+        Map<Integer, Household> householdMap = new LinkedHashMap<>();
+        Map<Integer, Dwelling> dwellingMap = new LinkedHashMap<>();
+        Map<Integer, Person> personMap = new LinkedHashMap<>();
         int ppHumber = 0;
         for (int hhNumber = 0; hhNumber < totalHouseholds; hhNumber++){
             Household hh = householdData.getHouseholdFromId(hhNumber + firstHouseholdMunicipality);
@@ -288,13 +288,13 @@ public class GenerateHouseholdsPersonsDwellings {
             return 0; //student
         } else {
 
-            Map<Integer, Double> expUtilities = new HashMap<>();
+            Map<Integer, Double> expUtilities = new LinkedHashMap<>();
             expUtilities.put(1, 1.0);
             for (int incomeCat = 2; incomeCat < 10; incomeCat++){
                 expUtilities.put(incomeCat, Math.exp(calculateUtilityForIncome(incomeCat, age, occupation, gender)));
             }
             double denominator = expUtilities.values().stream().mapToDouble(Double::doubleValue).sum();
-            Map<Integer, Double> probabilities = new HashMap<>();
+            Map<Integer, Double> probabilities = new LinkedHashMap<>();
             expUtilities.forEach((x,y)-> probabilities.put(x,y/denominator));
             int incomeCat = SiloUtil.select(probabilities);
             int income = (int) PropertiesSynPop.get().main.incomeCoefficients.getValueAt(incomeCat, "averageIncome");
@@ -438,7 +438,7 @@ public class GenerateHouseholdsPersonsDwellings {
         logger.info("   Municipality " + municipality + ". Starting to generate households and persons");
         totalHouseholds = (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "households");
 
-        probMicroData = new HashMap<>();
+        probMicroData = new LinkedHashMap<>();
         probabilityId = new double[dataSetSynPop.getWeights().getRowCount()];
         ids = new int[probabilityId.length];
         sumProbabilities = 0;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateJobs.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobs {
@@ -58,7 +59,7 @@ public class GenerateJobs {
 
 
     private void initializeTAZprobability(int municipality, String jobType){
-        jobsByTaz = new HashMap<>();
+        jobsByTaz = new LinkedHashMap<>();
         jobsByTaz.clear();
         for (int taz : dataSetSynPop.getTazByMunicipality().get(municipality)){
             jobsByTaz.put(taz, (float) Math.round(PropertiesSynPop.get().main.cellsMatrix.getIndexedValueAt(taz, jobType) * PropertiesSynPop.get().main.jobScaler));

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateVacantDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/allocation/GenerateVacantDwellings.java
@@ -29,7 +29,7 @@ public class GenerateVacantDwellings {
     private int highestDwellingIdInUse;
     private final DataContainer dataContainer;
     private RealEstateDataManager realEstateData;
-    private Map<Integer, List<Dwelling>> occupiedDwellings = new HashMap<>();
+    private Map<Integer, List<Dwelling>> occupiedDwellings = new LinkedHashMap<>();
 
 
     public GenerateVacantDwellings(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
@@ -103,11 +103,11 @@ public class GenerateVacantDwellings {
 
     private void initializeVacantDwellingData(int municipality){
 
-        probVacantFloor = new HashMap<>();
+        probVacantFloor = new LinkedHashMap<>();
         for (int floor : PropertiesSynPop.get().main.sizeBracketsDwelling) {
             probVacantFloor.put(floor, PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "vacantDwellings" + floor));
         }
-        probVacantBuildingSize = new HashMap<>();
+        probVacantBuildingSize = new LinkedHashMap<>();
         for (int year : PropertiesSynPop.get().main.yearBracketsDwelling){
             int sizeYear = year;
             String label = "vacantSmallDwellings" + year;
@@ -144,13 +144,13 @@ public class GenerateVacantDwellings {
                 }
                 ddQuality.put(key, qualities);
             } else {
-                Map<Integer, Float> qualities = new HashMap<>();
+                Map<Integer, Float> qualities = new LinkedHashMap<>();
                 qualities.put(quality, 1f);
                 ddQuality.put(key, qualities);
             }
         } else {
-            ddQuality = new HashMap<>();
-            Map<Integer, Float> qualities = new HashMap<>();
+            ddQuality = new LinkedHashMap<>();
+            Map<Integer, Float> qualities = new LinkedHashMap<>();
             qualities.put(quality, 1f);
             ddQuality.put(key, qualities);
         }
@@ -223,7 +223,7 @@ public class GenerateVacantDwellings {
     private int selectQualityVacant(int municipality, int year){
         int result = 0;
         if (ddQuality.get(year * 10000000 + municipality) == null) {
-            HashMap<Integer, Float> qualities = new HashMap<>();
+            HashMap<Integer, Float> qualities = new LinkedHashMap<>();
             for (int quality = 1; quality <= PropertiesSynPop.get().main.numberofQualityLevels; quality++){
                 qualities.put(quality, 1f);
             }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateDwellingMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateDwellingMicrolocation.java
@@ -12,6 +12,7 @@ import org.locationtech.jts.geom.Coordinate;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateDwellingMicrolocation {
@@ -20,13 +21,13 @@ public class GenerateDwellingMicrolocation {
     private static final double PENALTY = 0.5;
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private HashMap<Integer, Float> buildingX = new HashMap<>();
-    private HashMap<Integer, Float> buildingY = new HashMap<>();
-    private HashMap<Integer, HashMap<Integer,Double>> zoneBuildingMap = new HashMap<>();
-    Map<Integer, Integer> buildingZone = new HashMap<Integer, Integer>();
-    Map<Integer, Double> buildingArea = new HashMap<>();
-    Map<Integer, Float> zoneDensity = new HashMap<>();
-    Map<Integer, Integer> dwellingsInTAZ = new HashMap<Integer, Integer>();
+    private HashMap<Integer, Float> buildingX = new LinkedHashMap<>();
+    private HashMap<Integer, Float> buildingY = new LinkedHashMap<>();
+    private HashMap<Integer, HashMap<Integer,Double>> zoneBuildingMap = new LinkedHashMap<>();
+    Map<Integer, Integer> buildingZone = new LinkedHashMap<Integer, Integer>();
+    Map<Integer, Double> buildingArea = new LinkedHashMap<>();
+    Map<Integer, Float> zoneDensity = new LinkedHashMap<>();
+    Map<Integer, Integer> dwellingsInTAZ = new LinkedHashMap<Integer, Integer>();
 
     public GenerateDwellingMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataSetSynPop = dataSetSynPop;
@@ -79,7 +80,7 @@ public class GenerateDwellingMicrolocation {
             buildingZone.put(id,zone);
             //put all buildings with the same zoneID into one building list
             if (zoneBuildingMap.get(zone) == null){
-                HashMap<Integer, Double> buildingAreaList = new HashMap<Integer, Double>();
+                HashMap<Integer, Double> buildingAreaList = new LinkedHashMap<Integer, Double>();
                 zoneBuildingMap.put(zone,buildingAreaList);
             }
             zoneBuildingMap.get(zone).put(id,area);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateJobMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateJobMicrolocation.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.geom.Coordinate;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobMicrolocation {
@@ -21,12 +22,12 @@ public class GenerateJobMicrolocation {
     
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private Map<Integer, Float> jobX = new HashMap<>();
-    private Map<Integer, Float> jobY = new HashMap<>();
-    Map<Integer, Integer> jobZone = new HashMap<Integer, Integer>();
-    Map<Integer, Map<String,Map<Integer,Float>>> zoneJobTypeJobLocationArea = new HashMap<>();
-    Map<Integer, Map<String,Float>> zoneJobTypeDensity = new HashMap<>();
-    Map<Integer, Map<String,Integer>> jobsByJobTypeInTAZ = new HashMap<>();
+    private Map<Integer, Float> jobX = new LinkedHashMap<>();
+    private Map<Integer, Float> jobY = new LinkedHashMap<>();
+    Map<Integer, Integer> jobZone = new LinkedHashMap<Integer, Integer>();
+    Map<Integer, Map<String,Map<Integer,Float>>> zoneJobTypeJobLocationArea = new LinkedHashMap<>();
+    Map<Integer, Map<String,Float>> zoneJobTypeDensity = new LinkedHashMap<>();
+    Map<Integer, Map<String,Integer>> jobsByJobTypeInTAZ = new LinkedHashMap<>();
     
     public GenerateJobMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataSetSynPop = dataSetSynPop;
@@ -68,9 +69,9 @@ public class GenerateJobMicrolocation {
     private void readJobFile() {
 
         for (int zone : dataSetSynPop.getTazs()){
-            Map<String,Map<Integer,Float>> jobLocationListForThisJobType = new HashMap<>();
+            Map<String,Map<Integer,Float>> jobLocationListForThisJobType = new LinkedHashMap<>();
             for (String jobType : PropertiesSynPop.get().main.jobStringType){
-                Map<Integer,Float> jobLocationAndArea = new HashMap<>();
+                Map<Integer,Float> jobLocationAndArea = new LinkedHashMap<>();
                 jobLocationListForThisJobType.put(jobType,jobLocationAndArea);
             }
             zoneJobTypeJobLocationArea.put(zone,jobLocationListForThisJobType);
@@ -115,8 +116,8 @@ public class GenerateJobMicrolocation {
 
     private void calculateDensity() {
         for (int zone : dataSetSynPop.getTazs()){
-            Map<String,Integer> jobsByJobType = new HashMap<>();
-            Map<String,Float> densityByJobType = new HashMap<>();
+            Map<String,Integer> jobsByJobType = new LinkedHashMap<>();
+            Map<String,Float> densityByJobType = new LinkedHashMap<>();
             jobsByJobTypeInTAZ.put(zone,jobsByJobType);
             zoneJobTypeDensity.put(zone,densityByJobType);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateSchoolMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/GenerateSchoolMicrolocation.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateSchoolMicrolocation {
@@ -24,7 +25,7 @@ public class GenerateSchoolMicrolocation {
 
     private final DataContainerWithSchools dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new HashMap<>();
+    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new LinkedHashMap<>();
 
 
     public GenerateSchoolMicrolocation(DataContainerWithSchools dataContainer, DataSetSynPop dataSetSynPop){
@@ -74,9 +75,9 @@ public class GenerateSchoolMicrolocation {
     private void createSchools() {
 
         for (int zone : dataSetSynPop.getTazs()){
-            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new HashMap<>();
+            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new LinkedHashMap<>();
             for (int type = 1 ; type <= 3; type++){
-                Map<Integer,Integer> schoolCapacity = new HashMap<>();
+                Map<Integer,Integer> schoolCapacity = new LinkedHashMap<>();
                 schoolLocationListForThisSchoolType.put(type,schoolCapacity);
             }
             zoneSchoolTypeSchoolLocationCapacity.put(zone,schoolLocationListForThisSchoolType);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/Microlocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/microlocation/Microlocation.java
@@ -14,6 +14,7 @@ import org.geotools.api.feature.simple.SimpleFeature;
 import org.matsim.core.utils.gis.ShapeFileReader;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Microlocation extends ModuleSynPop {
@@ -30,7 +31,7 @@ public class Microlocation extends ModuleSynPop {
         logger.info("   Started microlocation model.");
 
         String zoneShapeFile = Properties.get().geo.zoneShapeFile;
-        Map<Integer, SimpleFeature> zoneFeatureMap = new HashMap<>();
+        Map<Integer, SimpleFeature> zoneFeatureMap = new LinkedHashMap<>();
         for (SimpleFeature feature: ShapeFileReader.getAllFeatures(zoneShapeFile)) {
             int zoneId = Integer.parseInt(feature.getAttribute("ZONE").toString());
             zoneFeatureMap.put(zoneId,feature);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/CheckHouseholdRelationship.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/CheckHouseholdRelationship.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CheckHouseholdRelationship {
@@ -576,11 +577,11 @@ public class CheckHouseholdRelationship {
         SiloUtil.addIntegerColumnToTableDataSet(microDataPerson, "rearrangedRole");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold,"nonClassifiedMales");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold, "nonClassifiedFemales");
-        childrenInHousehold = new HashMap<>();
-        noClass = new HashMap<>();
-        singles = new HashMap<>();
-        married = new HashMap<>();
-        headCouple = new HashMap<>();
+        childrenInHousehold = new LinkedHashMap<>();
+        noClass = new LinkedHashMap<>();
+        singles = new LinkedHashMap<>();
+        married = new LinkedHashMap<>();
+        headCouple = new LinkedHashMap<>();
     }
 
 
@@ -600,7 +601,7 @@ public class CheckHouseholdRelationship {
         }
         HashMap<Integer, Integer> inner = outer.get(key);
         if (inner == null){
-            inner = new HashMap<Integer, Integer>();
+            inner = new LinkedHashMap<Integer, Integer>();
             outer.put(key, inner);
         }
         inner.put(row, age);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/bangkok/preparation/ReadZonalData.java
@@ -15,6 +15,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ReadZonalData {
@@ -42,7 +43,7 @@ public class ReadZonalData {
         //List of municipalities and counties that are used for IPU and allocation
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         ArrayList<Integer> municipalitiesWithZero = new ArrayList<>();
         for (int row = 1; row <= PropertiesSynPop.get().main.selectedMunicipalities.getRowCount(); row++) {
             if (PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "Select") == 1f) {
@@ -69,13 +70,13 @@ public class ReadZonalData {
 
     private void readZones(){
         //TAZ attributes
-        HashMap<Integer, int[]> cityTAZ = new HashMap<>();
-        Map<Integer, Map<Integer, Float>> probabilityZone = new HashMap<>();
+        HashMap<Integer, int[]> cityTAZ = new LinkedHashMap<>();
+        Map<Integer, Map<Integer, Float>> probabilityZone = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = HashBasedTable.create();
         ArrayList<Integer> tazs = new ArrayList<>();
         ArrayList<Float> areas = new ArrayList<>();
         TableDataSet zoneAttributes = PropertiesSynPop.get().main.cellsMatrix;
-        HashMap<Integer, HashMap<String, Float>> attributesZone = new HashMap<>();
+        HashMap<Integer, HashMap<String, Float>> attributesZone = new LinkedHashMap<>();
 
         for (int i = 1; i <= zoneAttributes.getRowCount(); i++){
             int city = (int) zoneAttributes.getValueAt(i,"ID_city");
@@ -94,11 +95,11 @@ public class ReadZonalData {
             tazs.add(taz);
             int[] previousTaz = {taz};
             cityTAZ.put(city,previousTaz);
-            Map<Integer, Float> probabilities = new HashMap<>();
+            Map<Integer, Float> probabilities = new LinkedHashMap<>();
             probabilities.put(taz, probability);
             probabilityZone.put(city, probabilities);
             schoolCapacity.put(taz,1, (int) (capacitySchool * ratioJobs));
-            HashMap<String, Float> Attributes = new HashMap<>();
+            HashMap<String, Float> Attributes = new LinkedHashMap<>();
             Attributes.put("percentageVacantDwelings", percentageVacantDwellings);
             Attributes.put("income", averageIncome);
             Attributes.put("households", households);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCT.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCT.java
@@ -204,14 +204,14 @@ import org.apache.logging.log4j.Logger;
 //
 //        String fileName = "input/syntheticPopulation/variablesCTDictionary.csv";
 //
-//        attributeCodeValues = new HashMap<>();
-//        attributesControlTotal = new HashMap<>();
-//        attributesMicroPerson = new HashMap<>();
-//        attributesMicroHousehold = new HashMap<>();
-//        attributeCodeToControlTotal = new HashMap<>();
-//        attributeCodeToMicroPerson = new HashMap<>();
-//        attributeCodeToMicroHousehold = new HashMap<>();
-//        HashMap<Integer, String> attributeOrder = new HashMap<>();
+//        attributeCodeValues = new LinkedHashMap<>();
+//        attributesControlTotal = new LinkedHashMap<>();
+//        attributesMicroPerson = new LinkedHashMap<>();
+//        attributesMicroHousehold = new LinkedHashMap<>();
+//        attributeCodeToControlTotal = new LinkedHashMap<>();
+//        attributeCodeToMicroPerson = new LinkedHashMap<>();
+//        attributeCodeToMicroHousehold = new LinkedHashMap<>();
+//        HashMap<Integer, String> attributeOrder = new LinkedHashMap<>();
 //
 //        String recString = "";
 //        int recCount = 0;
@@ -320,7 +320,7 @@ import org.apache.logging.log4j.Logger;
 //        TableDataSet selectedMunicipalities = SiloUtil.readCSVfile(rb.getString(PROPERTIES_SELECTED_MUNICIPALITIES_LIST)); //TableDataSet with all municipalities
 //        municipalities = new ArrayList<>();
 //        counties = new ArrayList<>();
-//        municipalitiesByCounty = new HashMap<>();
+//        municipalitiesByCounty = new LinkedHashMap<>();
 //        for (int row = 1; row <= selectedMunicipalities.getRowCount(); row++){
 //            if (selectedMunicipalities.getValueAt(row,"Select") == 1f){
 //                int city = (int) selectedMunicipalities.getValueAt(row,"ID_city");
@@ -347,7 +347,7 @@ import org.apache.logging.log4j.Logger;
 //        //TAZ attributes
 //        cellsMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_RASTER_CELLS));
 //        cellsMatrix.buildIndex(cellsMatrix.getColumnPosition("ID_cell"));
-//        cityTAZ = new HashMap<>();
+//        cityTAZ = new LinkedHashMap<>();
 //        for (int i = 1; i <= cellsMatrix.getRowCount(); i++){
 //            int city = (int) cellsMatrix.getValueAt(i,"ID_city");
 //            int taz = (int) cellsMatrix.getValueAt(i,"ID_cell");
@@ -511,8 +511,8 @@ import org.apache.logging.log4j.Logger;
 //    private void readPersons() {
 //
 //        String fileName = "input/syntheticPopulation/newPersons.csv";
-//        personsInHouseholds = new HashMap<>();
-//        HashMap<Integer, HashMap<String, Integer>> noDatas = new HashMap<>();
+//        personsInHouseholds = new LinkedHashMap<>();
+//        HashMap<Integer, HashMap<String, Integer>> noDatas = new LinkedHashMap<>();
 //
 //        String recString = "";
 //        int recCount = 0;
@@ -524,7 +524,7 @@ import org.apache.logging.log4j.Logger;
 //            String[] header = recString.split(",");
 //            int posHhId   = SiloUtil.findPositionInArray("new$X.x", header);
 //            int posId   = SiloUtil.findPositionInArray("X.y",header);
-//            HashMap<String, Integer> positionAttribute = new HashMap<>();
+//            HashMap<String, Integer> positionAttribute = new LinkedHashMap<>();
 //            for (int i = 0; i < microPersonAttributes.length; i++){
 //                positionAttribute.put(microPersonAttributes[i], SiloUtil.findPositionInArray(microPersonAttributes[i], header));
 //            }
@@ -536,7 +536,7 @@ import org.apache.logging.log4j.Logger;
 //                int idHh = Integer.parseInt(lineElements[posHhId]);
 //                Integer id = Integer.parseInt(lineElements[posId]);
 //                recCount++;
-//                HashMap<String, Integer> attributeMap = new HashMap<>();
+//                HashMap<String, Integer> attributeMap = new LinkedHashMap<>();
 //                attributeMap.put("hhId", idHh);
 //                boolean allData = true;
 //                for (int i = 0; i < microPersonAttributes.length; i++){
@@ -598,7 +598,7 @@ import org.apache.logging.log4j.Logger;
 //
 //        String fileName = "input/syntheticPopulation/newHouseholds.csv";
 //
-//        households = new HashMap<>();
+//        households = new LinkedHashMap<>();
 //        String recString = "";
 //        int recCount = 0;
 //        try {
@@ -608,7 +608,7 @@ import org.apache.logging.log4j.Logger;
 //            // read header
 //            String[] header = recString.split(",");
 //            int posId = SiloUtil.findPositionInArray("X.x", header);
-//            HashMap<String, Integer> positionAttribute = new HashMap<>();
+//            HashMap<String, Integer> positionAttribute = new LinkedHashMap<>();
 //            for (Map.Entry<String, String> pairCode : attributeCodeToMicroHousehold.entrySet()){
 //                String attributeMicro = pairCode.getValue();
 //                positionAttribute.put(attributeMicro, SiloUtil.findPositionInArray(attributeMicro, header));
@@ -619,7 +619,7 @@ import org.apache.logging.log4j.Logger;
 //                recCount++;
 //                String[] lineElements = recString.split(",");
 //                int idhH = Integer.parseInt(lineElements[posId]);
-//                HashMap<String, Integer> attributeMap = new HashMap<>();
+//                HashMap<String, Integer> attributeMap = new LinkedHashMap<>();
 //                for (Map.Entry<String, String> pairCode : attributeCodeToMicroHousehold.entrySet()){
 //                    String attribute = pairCode.getKey();
 //                    String attributeMicro =  pairCode.getValue();
@@ -805,10 +805,10 @@ import org.apache.logging.log4j.Logger;
 //            } else {
 //
 //                //Create the maps to store the classified members of the households
-//                HashMap<Integer, Integer> childrenInHousehold = new HashMap<>();
-//                HashMap<String, HashMap<Integer, Integer>> noClass = new HashMap<>();
-//                HashMap<String, HashMap<Integer, Integer>> singles = new HashMap<>();
-//                HashMap<String, HashMap<Integer, Integer>> married = new HashMap<>();
+//                HashMap<Integer, Integer> childrenInHousehold = new LinkedHashMap<>();
+//                HashMap<String, HashMap<Integer, Integer>> noClass = new LinkedHashMap<>();
+//                HashMap<String, HashMap<Integer, Integer>> singles = new LinkedHashMap<>();
+//                HashMap<String, HashMap<Integer, Integer>> married = new LinkedHashMap<>();
 //
 //                //direct classification of the members of the household
 //                for (int j = 0; j < hhSize; j++) {
@@ -1054,13 +1054,13 @@ import org.apache.logging.log4j.Logger;
 //            municipalities = municipalitiesByCounty.get(county);
 //
 //            //weights, values, control totals
-//            Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new HashMap<>());
-//            Map<Integer, double[]> minWeightsByMun = Collections.synchronizedMap(new HashMap<>());
-//            Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-//            Map<String, Integer> totalCounty = Collections.synchronizedMap(new HashMap<>());
-//            Map<Integer, Map<String, Integer>> totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-//            Map<Integer, Map<String, Double>> errorByMun = Collections.synchronizedMap(new HashMap<>());
-//            Map<String, Double> errorByRegion = Collections.synchronizedMap(new HashMap<>());
+//            Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<Integer, double[]> minWeightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<String, Integer> totalCounty = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<Integer, Map<String, Integer>> totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<Integer, Map<String, Double>> errorByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+//            Map<String, Double> errorByRegion = Collections.synchronizedMap(new LinkedHashMap<>());
 //            double weightedSum0 = 0f;
 //
 //            //parameters of the IPU
@@ -1109,10 +1109,10 @@ import org.apache.logging.log4j.Logger;
 //                        inner1.put(attribute, 0.);
 //                        errorByMun.put(municipality, inner1);
 //                    } else {
-//                        HashMap<String, Integer> inner = new HashMap<>();
+//                        HashMap<String, Integer> inner = new LinkedHashMap<>();
 //                        inner.put(attribute, (int) marginalsMunicipality.getIndexedValueAt(municipality, attribute));
 //                        totalMunicipality.put(municipality, inner);
-//                        HashMap<String, Double> inner1 = new HashMap<>();
+//                        HashMap<String, Double> inner1 = new LinkedHashMap<>();
 //                        inner1.put(attribute, 0.);
 //                        errorByMun.put(municipality, inner1);
 //                    }
@@ -1177,7 +1177,7 @@ import org.apache.logging.log4j.Logger;
 //                Iterator<Integer> iterator1 = municipalities.iterator();
 //                while (iterator1.hasNext()){
 //                    Integer municipality = iterator1.next();
-//                    Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new HashMap<>());
+//                    Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
 //                    executor1.addTaskToQueue(() ->{
 //                        for (String attribute : attributesMunicipality){
 //                            double weightedSumMunicipality = SiloUtil.sumProduct(weightsByMun.get(municipality), valuesByHousehold.get(attribute));
@@ -1833,11 +1833,11 @@ import org.apache.logging.log4j.Logger;
 //
 //        //Driver license probability
 //        TableDataSet probabilityDriverLicense = SiloUtil.readCSVfile("input/syntheticPopulation/driverLicenseProb.csv");
-//        educationalLevelByPerson = new HashMap<>();
+//        educationalLevelByPerson = new LinkedHashMap<>();
 //        generateCountersForValidation();
 //
 //        //Create hashmaps to store quality of occupied dwellings
-//        HashMap<Integer, int[]> ddQuality = new HashMap<>();
+//        HashMap<Integer, int[]> ddQuality = new LinkedHashMap<>();
 //        numberofQualityLevels = ResourceUtil.getIntegerProperty(rb, PROPERTIES_NUMBER_OF_DWELLING_QUALITY_LEVELS);
 //        for (int municipality = 0; municipality < cityID.length; municipality++){
 //            for (int year : yearBracketsDwelling){
@@ -2363,13 +2363,13 @@ import org.apache.logging.log4j.Logger;
 //        logger.info("  Identifying vacant jobs by zone");
 //        Collection<Job> jobs = dataContainer.getJobData().getJobs();
 //
-//        idVacantJobsByZoneType = new HashMap<>();
-//        numberVacantJobsByType = new HashMap<>();
-//        idZonesVacantJobsByType = new HashMap<>();
-//        numberZonesByType = new HashMap<>();
-//        numberVacantJobsByZoneByType = new HashMap<>();
+//        idVacantJobsByZoneType = new LinkedHashMap<>();
+//        numberVacantJobsByType = new LinkedHashMap<>();
+//        idZonesVacantJobsByType = new LinkedHashMap<>();
+//        numberZonesByType = new LinkedHashMap<>();
+//        numberVacantJobsByZoneByType = new LinkedHashMap<>();
 //        jobStringTypes = ResourceUtil.getArray(rb, PROPERTIES_JOB_TYPES);
-//        jobIntTypes = new HashMap<>();
+//        jobIntTypes = new LinkedHashMap<>();
 //        for (int i = 0; i < jobStringTypes.length; i++) {
 //            jobIntTypes.put(jobStringTypes[i], i);
 //        }
@@ -2437,10 +2437,10 @@ import org.apache.logging.log4j.Logger;
 //    private void identifyVacantSchoolsByZoneByType(){
 //        logger.info("   Create vacant schools");
 //
-//        numberVacantSchoolsByZoneByType = new HashMap<>();
-//        numberZonesWithVacantSchoolsByType = new HashMap<>();
-//        idZonesVacantSchoolsByType = new HashMap<>();
-//        schoolCapacityByType = new HashMap<>();
+//        numberVacantSchoolsByZoneByType = new LinkedHashMap<>();
+//        numberZonesWithVacantSchoolsByType = new LinkedHashMap<>();
+//        idZonesVacantSchoolsByType = new LinkedHashMap<>();
+//        schoolCapacityByType = new LinkedHashMap<>();
 //        schoolTypes = ResourceUtil.getIntegerArray(rb, PROPERTIES_SCHOOL_TYPES_DE);
 //        int[] cellsID = cellsMatrix.getColumnAsInt("ID_cell");
 //
@@ -2964,7 +2964,7 @@ import org.apache.logging.log4j.Logger;
 //        }
 //        HashMap<Integer, Integer> inner = outer.get(key);
 //        if (inner == null){
-//            inner = new HashMap<Integer, Integer>();
+//            inner = new LinkedHashMap<Integer, Integer>();
 //            outer.put(key, inner);
 //        }
 //        inner.put(row, age);
@@ -3089,7 +3089,7 @@ import org.apache.logging.log4j.Logger;
 //            innerMap.put(valueString, valueCode);
 //            map.put(label, innerMap);
 //        } else {
-//            HashMap<String, Integer> innerMap = new HashMap<>();
+//            HashMap<String, Integer> innerMap = new LinkedHashMap<>();
 //            innerMap.put(valueString, valueCode);
 //            map.put(label, innerMap);
 //        }
@@ -3103,7 +3103,7 @@ import org.apache.logging.log4j.Logger;
 //            innerMap.put(valueString, valueCode);
 //            map.put(label, innerMap);
 //        } else {
-//            Map<String, Double> innerMap = new HashMap<>();
+//            Map<String, Double> innerMap = new LinkedHashMap<>();
 //            innerMap.put(valueString, valueCode);
 //            map.put(label, innerMap);
 //        }
@@ -3117,7 +3117,7 @@ import org.apache.logging.log4j.Logger;
 //            innerMap.put(valueInt, valueCode);
 //            map.put(label, innerMap);
 //        } else {
-//            HashMap<Integer, Integer> innerMap = new HashMap<>();
+//            HashMap<Integer, Integer> innerMap = new LinkedHashMap<>();
 //            innerMap.put(valueInt, valueCode);
 //            map.put(label, innerMap);
 //        }
@@ -3130,7 +3130,7 @@ import org.apache.logging.log4j.Logger;
 //            inner.put(id, attributeMap);
 //            personsInHouseholds.put(hhId, inner);
 //        } else {
-//            HashMap<Integer, HashMap<String, Integer>> inner = new HashMap<>();
+//            HashMap<Integer, HashMap<String, Integer>> inner = new LinkedHashMap<>();
 //            inner.put(id, attributeMap);
 //            personsInHouseholds.put(hhId, inner);
 //        }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCTrace.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/capeTown/SyntheticPopCTrace.java
@@ -235,14 +235,14 @@ public class SyntheticPopCTrace implements SyntheticPopI {
 
         String fileName = "input/syntheticPopulation/variablesCTDictionary.csv";
 
-        attributeCodeValues = new HashMap<>();
-        attributesControlTotal = new HashMap<>();
-        attributesMicroPerson = new HashMap<>();
-        attributesMicroHousehold = new HashMap<>();
-        attributeCodeToControlTotal = new HashMap<>();
-        attributeCodeToMicroPerson = new HashMap<>();
-        attributeCodeToMicroHousehold = new HashMap<>();
-        HashMap<Integer, String> attributeOrder = new HashMap<>();
+        attributeCodeValues = new LinkedHashMap<>();
+        attributesControlTotal = new LinkedHashMap<>();
+        attributesMicroPerson = new LinkedHashMap<>();
+        attributesMicroHousehold = new LinkedHashMap<>();
+        attributeCodeToControlTotal = new LinkedHashMap<>();
+        attributeCodeToMicroPerson = new LinkedHashMap<>();
+        attributeCodeToMicroHousehold = new LinkedHashMap<>();
+        HashMap<Integer, String> attributeOrder = new LinkedHashMap<>();
         ageBracketsPerson = new int[]{6,14,18,21,25,30,35,40,45,50,55,60,65,70,75,80,120};
 
         String recString = "";
@@ -352,7 +352,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         TableDataSet selectedMunicipalities = SiloUtil.readCSVfile(rb.getString(PROPERTIES_SELECTED_MUNICIPALITIES_LIST)); //TableDataSet with all municipalities
         municipalities = new ArrayList<>();
         counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         for (int row = 1; row <= selectedMunicipalities.getRowCount(); row++){
             if (selectedMunicipalities.getValueAt(row,"Select") == 1f){
                 int city = (int) selectedMunicipalities.getValueAt(row,"ID_city");
@@ -379,7 +379,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         //TAZ attributes
         cellsMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_RASTER_CELLS));
         cellsMatrix.buildIndex(cellsMatrix.getColumnPosition("ID_cell"));
-        cityTAZ = new HashMap<>();
+        cityTAZ = new LinkedHashMap<>();
         for (int i = 1; i <= cellsMatrix.getRowCount(); i++){
             int city = (int) cellsMatrix.getValueAt(i,"ID_city");
             int taz = (int) cellsMatrix.getValueAt(i,"ID_cell");
@@ -413,7 +413,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         //Read trip length frequency distribution
         logger.info("   Starting to read trip length frequency distribution");
         TableDataSet tripLength = SiloUtil.readCSVfile2(rb.getString(PROPERTIES_TRIP_LENGTH_DISTRIBUTION));
-        tripLengthFrequencyDistribution = new HashMap<>();
+        tripLengthFrequencyDistribution = new LinkedHashMap<>();
         for (int i = 1; i <= tripLength.getRowCount(); i++){
             int distance = (int) tripLength.getValueAt(i, "km");
             float value = tripLength.getValueAt(i, "HBW");
@@ -550,8 +550,8 @@ public class SyntheticPopCTrace implements SyntheticPopI {
     private void readPersons() {
 
         String fileName = "input/syntheticPopulation/newPersons.csv";
-        personsInHouseholds = new HashMap<>();
-        HashMap<Integer, HashMap<String, Integer>> noDatas = new HashMap<>();
+        personsInHouseholds = new LinkedHashMap<>();
+        HashMap<Integer, HashMap<String, Integer>> noDatas = new LinkedHashMap<>();
 
         String recString = "";
         int recCount = 0;
@@ -563,7 +563,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             String[] header = recString.split(",");
             int posHhId   = SiloUtil.findPositionInArray("new$X.x", header);
             int posId   = SiloUtil.findPositionInArray("X.y",header);
-            HashMap<String, Integer> positionAttribute = new HashMap<>();
+            HashMap<String, Integer> positionAttribute = new LinkedHashMap<>();
             for (int i = 0; i < microPersonAttributes.length; i++){
                 positionAttribute.put(microPersonAttributes[i], SiloUtil.findPositionInArray(microPersonAttributes[i], header));
             }
@@ -575,7 +575,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
                 int idHh = Integer.parseInt(lineElements[posHhId]);
                 Integer id = Integer.parseInt(lineElements[posId]);
                 recCount++;
-                HashMap<String, Integer> attributeMap = new HashMap<>();
+                HashMap<String, Integer> attributeMap = new LinkedHashMap<>();
                 attributeMap.put("hhId", idHh);
                 boolean allData = true;
                 for (int i = 0; i < microPersonAttributes.length; i++){
@@ -637,7 +637,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
 
         String fileName = "input/syntheticPopulation/newHouseholds.csv";
 
-        households = new HashMap<>();
+        households = new LinkedHashMap<>();
         String recString = "";
         int recCount = 0;
         try {
@@ -647,7 +647,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             // read header
             String[] header = recString.split(",");
             int posId = SiloUtil.findPositionInArray("X.x", header);
-            HashMap<String, Integer> positionAttribute = new HashMap<>();
+            HashMap<String, Integer> positionAttribute = new LinkedHashMap<>();
             for (Map.Entry<String, String> pairCode : attributeCodeToMicroHousehold.entrySet()){
                 String attributeMicro = pairCode.getValue();
                 positionAttribute.put(attributeMicro, SiloUtil.findPositionInArray(attributeMicro, header));
@@ -658,7 +658,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
                 recCount++;
                 String[] lineElements = recString.split(",");
                 int idhH = Integer.parseInt(lineElements[posId]);
-                HashMap<String, Integer> attributeMap = new HashMap<>();
+                HashMap<String, Integer> attributeMap = new LinkedHashMap<>();
                 for (Map.Entry<String, String> pairCode : attributeCodeToMicroHousehold.entrySet()){
                     String attribute = pairCode.getKey();
                     String attributeMicro =  pairCode.getValue();
@@ -852,10 +852,10 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             } else {
 
                 //Create the maps to store the classified members of the households
-                HashMap<Integer, Integer> childrenInHousehold = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> noClass = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> singles = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> married = new HashMap<>();
+                HashMap<Integer, Integer> childrenInHousehold = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> noClass = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> singles = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> married = new LinkedHashMap<>();
 
                 //direct classification of the members of the household
                 for (int j = 0; j < hhSize; j++) {
@@ -1137,10 +1137,10 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             } else {
 
                 //Create the maps to store the classified members of the households
-                HashMap<Integer, Integer> childrenInHousehold = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> noClass = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> singles = new HashMap<>();
-                HashMap<String, HashMap<Integer, Integer>> married = new HashMap<>();
+                HashMap<Integer, Integer> childrenInHousehold = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> noClass = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> singles = new LinkedHashMap<>();
+                HashMap<String, HashMap<Integer, Integer>> married = new LinkedHashMap<>();
 
                 //direct classification of the members of the household
                 int row = 0;
@@ -1457,13 +1457,13 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             municipalities = municipalitiesByCounty.get(county);
 
             //weights, values, control totals
-            Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new HashMap<>());
-            Map<Integer, double[]> minWeightsByMun = Collections.synchronizedMap(new HashMap<>());
-            Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-            Map<String, Integer> totalCounty = Collections.synchronizedMap(new HashMap<>());
-            Map<Integer, Map<String, Integer>> totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-            Map<Integer, Map<String, Double>> errorByMun = Collections.synchronizedMap(new HashMap<>());
-            Map<String, Double> errorByRegion = Collections.synchronizedMap(new HashMap<>());
+            Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<Integer, double[]> minWeightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<String, Integer> totalCounty = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<Integer, Map<String, Integer>> totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<Integer, Map<String, Double>> errorByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<String, Double> errorByRegion = Collections.synchronizedMap(new LinkedHashMap<>());
             double weightedSum0 = 0f;
 
             //parameters of the IPU
@@ -1512,10 +1512,10 @@ public class SyntheticPopCTrace implements SyntheticPopI {
                         inner1.put(attribute, 0.);
                         errorByMun.put(municipality, inner1);
                     } else {
-                        HashMap<String, Integer> inner = new HashMap<>();
+                        HashMap<String, Integer> inner = new LinkedHashMap<>();
                         inner.put(attribute, (int) marginalsMunicipality.getIndexedValueAt(municipality, attribute));
                         totalMunicipality.put(municipality, inner);
-                        HashMap<String, Double> inner1 = new HashMap<>();
+                        HashMap<String, Double> inner1 = new LinkedHashMap<>();
                         inner1.put(attribute, 0.);
                         errorByMun.put(municipality, inner1);
                     }
@@ -1580,7 +1580,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
                 Iterator<Integer> iterator1 = municipalities.iterator();
                 while (iterator1.hasNext()){
                     Integer municipality = iterator1.next();
-                    Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new HashMap<>());
+                    Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
                     executor1.addTaskToQueue(() ->{
                         for (String attribute : attributesMunicipality){
                             double weightedSumMunicipality = SiloUtil.sumProduct(weightsByMun.get(municipality), valuesByHousehold.get(attribute));
@@ -1785,8 +1785,8 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         Collections.shuffle(workerArrayList);
 
 
-        HashMap<Integer, Float> personDistance = new HashMap<>();
-        HashMap<Integer, Integer> personHome = new HashMap<>();
+        HashMap<Integer, Float> personDistance = new LinkedHashMap<>();
+        HashMap<Integer, Integer> personHome = new LinkedHashMap<>();
 
         //Start the selection of the jobs in random order to avoid geographical bias
         logger.info("   Started assigning workplaces");
@@ -1884,7 +1884,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         int previousPersons = 0;
 
         generateCountersForValidation();
-        occupiedDwellingsByZone = new HashMap<>();
+        occupiedDwellingsByZone = new LinkedHashMap<>();
 
         RealEstateDataManager realEstate = dataContainer.getRealEstateDataManager();
         HouseholdDataManager householdDataManager = dataContainer.getHouseholdDataManager();
@@ -1988,7 +1988,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
                 if (occupiedDwellingsByZone.containsKey(taz)) {
                     occupiedDwellingsByZone.get(taz).put(dwell.getId(), dwell);
                 } else {
-                    Map<Integer, Dwelling> dd = new HashMap<>();
+                    Map<Integer, Dwelling> dd = new LinkedHashMap<>();
                     dd.put(dwell.getId(), dwell);
                     occupiedDwellingsByZone.put(taz,dd);
                 }
@@ -2208,13 +2208,13 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         logger.info("  Identifying vacant jobs by zone");
         Collection<Job> jobs = dataContainer.getJobDataManager().getJobs();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
         jobStringTypes = ResourceUtil.getArray(rb, PROPERTIES_JOB_TYPES);
-        jobIntTypes = new HashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < jobStringTypes.length; i++) {
             jobIntTypes.put(jobStringTypes[i], i);
         }
@@ -2573,7 +2573,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
         }
         HashMap<Integer, Integer> inner = outer.get(key);
         if (inner == null){
-            inner = new HashMap<Integer, Integer>();
+            inner = new LinkedHashMap<Integer, Integer>();
             outer.put(key, inner);
         }
         inner.put(row, age);
@@ -2729,7 +2729,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             innerMap.put(valueString, valueCode);
             map.put(label, innerMap);
         } else {
-            HashMap<String, Integer> innerMap = new HashMap<>();
+            HashMap<String, Integer> innerMap = new LinkedHashMap<>();
             innerMap.put(valueString, valueCode);
             map.put(label, innerMap);
         }
@@ -2743,7 +2743,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             innerMap.put(valueString, valueCode);
             map.put(label, innerMap);
         } else {
-            Map<String, Double> innerMap = new HashMap<>();
+            Map<String, Double> innerMap = new LinkedHashMap<>();
             innerMap.put(valueString, valueCode);
             map.put(label, innerMap);
         }
@@ -2757,7 +2757,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             innerMap.put(valueInt, valueCode);
             map.put(label, innerMap);
         } else {
-            HashMap<Integer, Integer> innerMap = new HashMap<>();
+            HashMap<Integer, Integer> innerMap = new LinkedHashMap<>();
             innerMap.put(valueInt, valueCode);
             map.put(label, innerMap);
         }
@@ -2770,7 +2770,7 @@ public class SyntheticPopCTrace implements SyntheticPopI {
             inner.put(id, attributeMap);
             personsInHouseholds.put(hhId, inner);
         } else {
-            HashMap<Integer, HashMap<String, Integer>> inner = new HashMap<>();
+            HashMap<Integer, HashMap<String, Integer>> inner = new LinkedHashMap<>();
             inner.put(id, attributeMap);
             personsInHouseholds.put(hhId, inner);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/SyntheticPopGermanyMito.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/SyntheticPopGermanyMito.java
@@ -155,9 +155,9 @@ public class SyntheticPopGermanyMito implements SyntheticPopI {
 
     private void writeMultipleFilesForHouseholdsAndPersons(DataContainerWithSchools dataContainer){
 
-        Map<Integer, PrintWriter> householdWriter = new HashMap<>();
-        Map<Integer, PrintWriter> personWriter = new HashMap<>();
-        Map<Integer, PrintWriter> dwellingWriter = new HashMap<>();
+        Map<Integer, PrintWriter> householdWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> personWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> dwellingWriter = new LinkedHashMap<>();
 
         String outputFolder = properties.main.baseDirectory  + PropertiesSynPop.get().main.pathSyntheticPopulationFiles
                 + "/subPopulations/" + PropertiesSynPop.get().main.state + "/";

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/SyntheticPopGermanyMitoByState.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/SyntheticPopGermanyMitoByState.java
@@ -29,10 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
 /**
@@ -248,9 +245,9 @@ public class SyntheticPopGermanyMitoByState implements SyntheticPopI {
 
     private void writeMultipleFilesForHouseholdsAndPersons(DataContainerWithSchools dataContainer){
 
-        Map<Integer, PrintWriter> householdWriter = new HashMap<>();
-        Map<Integer, PrintWriter> personWriter = new HashMap<>();
-        Map<Integer, PrintWriter> dwellingWriter = new HashMap<>();
+        Map<Integer, PrintWriter> householdWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> personWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> dwellingWriter = new LinkedHashMap<>();
 
         String outputFolder = properties.main.baseDirectory  + PropertiesSynPop.get().main.pathSyntheticPopulationFiles
                 + "/subPopulations/" + PropertiesSynPop.get().main.state + "/";
@@ -383,9 +380,9 @@ public class SyntheticPopGermanyMitoByState implements SyntheticPopI {
 
     private void writesubsample(DataContainerWithSchools dataContainer, int samplingRate){
 
-        Map<Integer, PrintWriter> householdWriter = new HashMap<>();
-        Map<Integer, PrintWriter> personWriter = new HashMap<>();
-        Map<Integer, PrintWriter> dwellingWriter = new HashMap<>();
+        Map<Integer, PrintWriter> householdWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> personWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> dwellingWriter = new LinkedHashMap<>();
 
         String outputFolder = properties.main.baseDirectory  + PropertiesSynPop.get().main.pathSyntheticPopulationFiles
                 + "/subPopulations00/" ;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignJobs.java
@@ -159,18 +159,18 @@ public class AssignJobs {
         TableDataSet jobsByTaz = PropertiesSynPop.get().main.jobsByTaz;
 
         jobStringTypes = PropertiesSynPop.get().main.jobStringType;
-        jobIntTypes = new HashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }
         tazIds = dataSetSynPop.getTazs().stream().mapToInt(i -> i).toArray();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
-        numberTotalJobsByZoneByType = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
+        numberTotalJobsByZoneByType = new LinkedHashMap<>();
 
         //create the counter hashmaps
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++){

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignJobsBySubpopulation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignJobsBySubpopulation.java
@@ -101,7 +101,7 @@ public class AssignJobsBySubpopulation {
     }
 
     private Map<Integer, Double> calculateDistanceProbabilityByJobType(String jobType, int origin, double alpha_ld, double beta_ld) {
-        Map<Integer, Double> probabilityByTypeAndZone = new HashMap<>();
+        Map<Integer, Double> probabilityByTypeAndZone = new LinkedHashMap<>();
         TableDataSet jobsByTaz = PropertiesSynPop.get().main.jobsByTaz;
         for (int destination : dataSetSynPop.getVacantJobsByTypeAndZone().get(jobType).keySet()) {
             float distance = dataSetSynPop.getDistanceTazToTaz().getValueAt(origin, destination);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignSchools.java
@@ -102,7 +102,7 @@ public class AssignSchools {
 
         int schooltaz = -2;
         if (numberOfVacantPlacesByType.get(3) > 0) {
-            Map<Integer, Float> probability = new HashMap<>();
+            Map<Integer, Float> probability = new LinkedHashMap<>();
             Iterator<Integer> iterator = schoolCapacityMap.get(3).keySet().iterator();
 
             double alpha1 = 0.3000;   //0.2700, 0.3000
@@ -171,8 +171,8 @@ public class AssignSchools {
 
     private void initializeSchoolCapacity(){
 
-        schoolCapacityMap = new HashMap<>();
-        numberOfVacantPlacesByType = new HashMap<>();
+        schoolCapacityMap = new LinkedHashMap<>();
+        numberOfVacantPlacesByType = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = dataSetSynPop.getSchoolCapacity();
         Iterator<Integer> iteratorRow = schoolCapacity.rowKeySet().iterator();
         while (iteratorRow.hasNext()){
@@ -182,7 +182,7 @@ public class AssignSchools {
                 int schoolType = iteratorCol.next();
                 int places = schoolCapacity.get(zone, schoolType);
                 if (places > 0) {
-                    Map<Integer, Integer> prevPlaces = new HashMap<>();
+                    Map<Integer, Integer> prevPlaces = new LinkedHashMap<>();
                     if (schoolCapacityMap.get(schoolType)!= null) {
                         prevPlaces = schoolCapacityMap.get(schoolType);
                     }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignSchoolsBySubpopulation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/AssignSchoolsBySubpopulation.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AssignSchoolsBySubpopulation {
@@ -116,7 +117,7 @@ public class AssignSchoolsBySubpopulation {
     }
 
     private Map<Integer, Double> calculateDistanceProbabilityBySchoolType(int schoolType, int origin, double alpha_ld, double beta_ld) {
-        Map<Integer, Double> probabilityByTypeAndZone = new HashMap<>();
+        Map<Integer, Double> probabilityByTypeAndZone = new LinkedHashMap<>();
         TableDataSet jobsByTaz = PropertiesSynPop.get().main.jobsByTaz;
         if (schoolType == 3) {
             float minDistance = 10000;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateHouseholdsPersons.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateHouseholdsPersons.java
@@ -163,7 +163,7 @@ public class GenerateHouseholdsPersons {
             totalHouseholds = (int) PropertiesSynPop.get().main.marginalsBorough.getIndexedValueAt(municipality, "borough_hhTotal");
         }
         probTAZ = dataSetSynPop.getProbabilityZone().get(municipality);
-        probMicroData = new HashMap<>();
+        probMicroData = new LinkedHashMap<>();
         probabilityId = new double[dataSetSynPop.getWeights().getRowCount()];
         ids = new int[probabilityId.length];
         sumProbabilities = 0;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateJobCounters.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateJobCounters.java
@@ -37,13 +37,13 @@ public class GenerateJobCounters {
 
     private void generateJobCounters(){
         logger.info("  Generating counters with vacant jobs by zone");
-        Map<String, Map<Integer, Integer>> vacantJobsByTypeAndZone = new HashMap<>();
-        Map<String, Map<Integer, Integer>> assignedJobsByTypeAndZone = new HashMap<>();
+        Map<String, Map<Integer, Integer>> vacantJobsByTypeAndZone = new LinkedHashMap<>();
+        Map<String, Map<Integer, Integer>> assignedJobsByTypeAndZone = new LinkedHashMap<>();
         assignedJobs = 0;
         TableDataSet jobsByTaz = PropertiesSynPop.get().main.jobsByTaz;
         for (String jobType : JobType.getJobTypes()) {
-            //vacantJobsByTypeAndZone.putIfAbsent(jobType, new HashMap<>());
-            assignedJobsByTypeAndZone.putIfAbsent(jobType, new HashMap<>());
+            //vacantJobsByTypeAndZone.putIfAbsent(jobType, new LinkedHashMap<>());
+            assignedJobsByTypeAndZone.putIfAbsent(jobType, new LinkedHashMap<>());
             for (int taz : jobsByTaz.getColumnAsInt("taz")) {
                 //int jobs = (int) jobsByTaz.getValueAt(taz, jobType) * (1 + PropertiesSynPop.get().main.vacantJobPercentage / 100);
                 //vacantJobsByTypeAndZone.get(jobType).putIfAbsent(taz, jobs);
@@ -52,7 +52,7 @@ public class GenerateJobCounters {
             }
         }
 
-        vacantJobsByTypeAndZone.putIfAbsent("all", new HashMap<>());
+        vacantJobsByTypeAndZone.putIfAbsent("all", new LinkedHashMap<>());
         for (int taz : jobsByTaz.getColumnAsInt("taz")) {
             int jobs = 0;
             for (String jobType : JobType.getJobTypes()) {

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateJobs.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 
@@ -79,7 +80,7 @@ public class GenerateJobs {
 
 
     private void initializeTAZprobability(int municipality, String jobType){
-        jobsByTaz = new HashMap<>();
+        jobsByTaz = new LinkedHashMap<>();
         jobsByTaz.clear();
         for (int taz : dataSetSynPop.getTazByMunicipality().get(municipality)){
             jobsByTaz.put(taz, PropertiesSynPop.get().main.cellsMatrix.getIndexedValueAt(taz, jobType));

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateSchoolMicrolocations.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/GenerateSchoolMicrolocations.java
@@ -22,6 +22,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateSchoolMicrolocations {
@@ -44,13 +45,13 @@ public class GenerateSchoolMicrolocations {
 
     private void createSchools() {
 
-        Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new HashMap<>();
-        Map<Integer, Map<Integer, Integer>> zoneSchoolTypeSchoolLocationVacancy = new HashMap<>();
+        Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new LinkedHashMap<>();
+        Map<Integer, Map<Integer, Integer>> zoneSchoolTypeSchoolLocationVacancy = new LinkedHashMap<>();
         for (int type = 1 ; type <= 3; type++){
-            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new HashMap<>();
-            Map<Integer, Integer> schoolLocationListForThisSchoolTypeVacancy = new HashMap<>();
+            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new LinkedHashMap<>();
+            Map<Integer, Integer> schoolLocationListForThisSchoolTypeVacancy = new LinkedHashMap<>();
             for (int zone : dataSetSynPop.getTazs()){
-                Map<Integer,Integer> schoolCapacity = new HashMap<>();
+                Map<Integer,Integer> schoolCapacity = new LinkedHashMap<>();
                 schoolLocationListForThisSchoolType.put(zone,schoolCapacity);
                 schoolLocationListForThisSchoolTypeVacancy.put(zone,0);
             }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/Read2011JobsForMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/Read2011JobsForMicrolocation.java
@@ -54,12 +54,12 @@ public class Read2011JobsForMicrolocation {
 
         Map<String, Map<Integer, Map<Integer, Coordinate>>> microlocationsJobsByTypeAndZone = new LinkedHashMap<>();
         for (String jobType : JobType.getJobTypes()) {
-            microlocationsJobsByTypeAndZone.putIfAbsent(jobType, new HashMap<>());
+            microlocationsJobsByTypeAndZone.putIfAbsent(jobType, new LinkedHashMap<>());
             for (int taz : PropertiesSynPop.get().main.jobsByTaz.getColumnAsInt("taz")) {
-                Map<Integer, Coordinate> centroidCoordinates = new HashMap<>();
+                Map<Integer, Coordinate> centroidCoordinates = new LinkedHashMap<>();
                 int coordX = dataSetSynPop.getZoneCoordinates().get(taz,"coordX");
                 int coordY = dataSetSynPop.getZoneCoordinates().get(taz,"coordY");
-                microlocationsJobsByTypeAndZone.get(jobType).putIfAbsent(taz, new HashMap<>());
+                microlocationsJobsByTypeAndZone.get(jobType).putIfAbsent(taz, new LinkedHashMap<>());
                 microlocationsJobsByTypeAndZone.get(jobType).get(taz).put(0, new Coordinate(coordX, coordY));
             }
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/ValidateTripLengthDistributionByState.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/allocation/ValidateTripLengthDistributionByState.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.Timestamp;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ValidateTripLengthDistributionByState {
@@ -54,7 +55,7 @@ public class ValidateTripLengthDistributionByState {
 
 
     private Map<String, Frequency> obtainWorkerFlows(){
-        Map<String, Frequency> frequencies = new HashMap<>();
+        Map<String, Frequency> frequencies = new LinkedHashMap<>();
         for (String jobType : JobType.getJobTypes()) {
             Frequency commuteDistance = new Frequency();
             frequencies.putIfAbsent(jobType, commuteDistance);
@@ -107,7 +108,7 @@ public class ValidateTripLengthDistributionByState {
     private void summarizeFlows(Map<String,Frequency> travelTimes, String fileName){
         //to obtain the trip length distribution
         int[] timeThresholds1 = new int[200];
-        Map<String, double[]> cumFrequency = new HashMap<>();
+        Map<String, double[]> cumFrequency = new LinkedHashMap<>();
         for (String keyFrequencies : travelTimes.keySet()) {
             double[] frequencyTT1 = new double[200];
             for (int row = 0; row < timeThresholds1.length; row++) {

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/io/ReadSubPopulations.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/io/ReadSubPopulations.java
@@ -360,9 +360,9 @@ public class ReadSubPopulations {
 
     private void writeMultipleFilesForHouseholdsAndPersons(DataContainerWithSchools dataContainer){
 
-        Map<Integer, PrintWriter> householdWriter = new HashMap<>();
-        Map<Integer, PrintWriter> personWriter = new HashMap<>();
-        Map<Integer, PrintWriter> dwellingWriter = new HashMap<>();
+        Map<Integer, PrintWriter> householdWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> personWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> dwellingWriter = new LinkedHashMap<>();
 
         String outputFolder = Properties.get().main.baseDirectory  + PropertiesSynPop.get().main.pathSyntheticPopulationFiles
                 + "/subPopulations/" + PropertiesSynPop.get().main.state + "/";
@@ -493,20 +493,20 @@ public class ReadSubPopulations {
     }
 
     private void startCounters(){
-        countsPreviousState = new HashMap<>();
-        countsPreviousState = new HashMap<>();
-        countsPreviousState.putIfAbsent("all", new HashMap<>());
+        countsPreviousState = new LinkedHashMap<>();
+        countsPreviousState = new LinkedHashMap<>();
+        countsPreviousState.putIfAbsent("all", new LinkedHashMap<>());
         countsPreviousState.get("all").putIfAbsent("hh", 0);
         countsPreviousState.get("all").put("pp", 0);
         countsPreviousState.get("all").put("dd", 0);
-        countsState = new HashMap<>();
-        countsState = new HashMap<>();
+        countsState = new LinkedHashMap<>();
+        countsState = new LinkedHashMap<>();
         for (String state : PropertiesSynPop.get().main.states) {
-            countsPreviousState.put(state, new HashMap<>());
+            countsPreviousState.put(state, new LinkedHashMap<>());
             countsPreviousState.get(state).putIfAbsent("hh", 0);
             countsPreviousState.get(state).put("pp", 0);
             countsPreviousState.get(state).put("dd", 0);
-            countsState.put(state, new HashMap<>());
+            countsState.put(state, new LinkedHashMap<>());
             countsState.get(state).putIfAbsent("hh", 0);
             countsState.get(state).put("pp", 0);
             countsState.get(state).put("dd", 0);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/io/WriteSubpopulationsByState.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/io/WriteSubpopulationsByState.java
@@ -14,10 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
 /**
@@ -56,9 +53,9 @@ public class WriteSubpopulationsByState {
 
     private void writeMultipleFilesForHouseholdsAndPersons(DataContainerWithSchools dataContainer){
 
-        Map<Integer, PrintWriter> householdWriter = new HashMap<>();
-        Map<Integer, PrintWriter> personWriter = new HashMap<>();
-        Map<Integer, PrintWriter> dwellingWriter = new HashMap<>();
+        Map<Integer, PrintWriter> householdWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> personWriter = new LinkedHashMap<>();
+        Map<Integer, PrintWriter> dwellingWriter = new LinkedHashMap<>();
 
         ArrayList<Household> householdArrayList = new ArrayList<>();
         for (Household hh : dataContainer.getHouseholdDataManager().getHouseholds()){

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/MicroDataManager.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/MicroDataManager.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MicroDataManager {
@@ -22,7 +23,7 @@ public class MicroDataManager {
 
     public HashMap<String, String[]> attributesMicroData(){
 
-        HashMap<String, String[]> attributesMicroData = new HashMap<>();
+        HashMap<String, String[]> attributesMicroData = new LinkedHashMap<>();
         String[] attributesPerson = {"age", "gender", "occupation", "income", "nationality", "school"};
         String[] attributesHousehold = {"workers", "hhSize"};
         attributesMicroData.put("person", attributesPerson);
@@ -33,34 +34,34 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesPersonMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> age = new HashMap<>();
+            Map<String, Integer> age = new LinkedHashMap<>();
                 age.put("initial", 50);
                 age.put("end", 52);
                 attributesIPU.put("age", age);
-            Map<String, Integer> gender = new HashMap<>();
+            Map<String, Integer> gender = new LinkedHashMap<>();
                 gender.put("initial", 54);
                 gender.put("end", 55);
                 attributesIPU.put("gender", gender);
-            Map<String, Integer> occupation = new HashMap<>();
+            Map<String, Integer> occupation = new LinkedHashMap<>();
                 occupation.put("initial", 32);
                 occupation.put("end", 33);
                 attributesIPU.put("occupation", occupation);
         //Additional attributes
-            Map<String, Integer> income = new HashMap<>();
+            Map<String, Integer> income = new LinkedHashMap<>();
                 income.put("initial", 471);
                 income.put("end", 473);
                 attributesIPU.put("income", income);
-            Map<String, Integer> sector = new HashMap<>();
+            Map<String, Integer> sector = new LinkedHashMap<>();
                 sector.put("initial", 479);
                 sector.put("end", 482);
                 attributesIPU.put("sector", sector);
-            Map<String, Integer> sectorComplete = new HashMap<>();
+            Map<String, Integer> sectorComplete = new LinkedHashMap<>();
                 sectorComplete.put("initial", 479);
                 sectorComplete.put("end", 482);
                 attributesIPU.put("sectorComplete", sectorComplete);
-            Map<String, Integer> school = new HashMap<>();
+            Map<String, Integer> school = new LinkedHashMap<>();
                 school.put("initial", 307);
                 school.put("end", 309);
                 attributesIPU.put("school", school);
@@ -70,14 +71,14 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesHouseholdMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> hhSize = new HashMap<>();
+            Map<String, Integer> hhSize = new LinkedHashMap<>();
                 hhSize.put("initial", 26);
                 hhSize.put("end", 28);
                 attributesIPU.put("hhSize", hhSize);
         //Additional attributes
-            Map<String, Integer> workers = new HashMap<>();
+            Map<String, Integer> workers = new LinkedHashMap<>();
                 workers.put("initial", 572);
                 workers.put("end", 574);
                 attributesIPU.put("workers", workers);
@@ -87,13 +88,13 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> exceptionsMicroData(String stateString){
 
-        Map<String, Map<String, Integer>> exceptionsMicroData = new HashMap<>();
-        Map<String, Integer> LivingInQuarter = new HashMap<>();
+        Map<String, Map<String, Integer>> exceptionsMicroData = new LinkedHashMap<>();
+        Map<String, Integer> LivingInQuarter = new LinkedHashMap<>();
         LivingInQuarter.put("initial", 34);
         LivingInQuarter.put("end", 35);
         LivingInQuarter.put("exceptionIf", 2);
         exceptionsMicroData.put("quarter", LivingInQuarter);
-        Map<String, Integer> noIncome = new HashMap<>();
+        Map<String, Integer> noIncome = new LinkedHashMap<>();
         noIncome.put("initial", 658);
         noIncome.put("end", 660);
         noIncome.put("exceptionIf", 99);
@@ -107,7 +108,7 @@ public class MicroDataManager {
         for (int i = 1; i < 16; i++ ) {
             if (i!=state) {
                 String nameState = "State" + i;
-                Map<String, Integer> key = new HashMap<>();
+                Map<String, Integer> key = new LinkedHashMap<>();
                 key.put("initial", 0);
                 key.put("end", 2);
                 key.put("exceptionIf", i);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/ReadMicroData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/ReadMicroData.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ReadMicroData {
@@ -22,10 +23,10 @@ public class ReadMicroData {
 
     private final DataSetSynPop dataSetSynPop;
     private final MicroDataManager microDataManager;
-    private Map<String, Map<String, Integer>> exceptionsMicroData = new HashMap<>();
-    private HashMap<String, String[]> attributesMicroData = new HashMap<>();
-    private Map<String, Map<String, Integer>> attributesPersonMicroData = new HashMap<>();
-    private Map<String, Map<String, Integer>> attributesHouseholdMicroData = new HashMap<>();
+    private Map<String, Map<String, Integer>> exceptionsMicroData = new LinkedHashMap<>();
+    private HashMap<String, String[]> attributesMicroData = new LinkedHashMap<>();
+    private Map<String, Map<String, Integer>> attributesPersonMicroData = new LinkedHashMap<>();
+    private Map<String, Map<String, Integer>> attributesHouseholdMicroData = new LinkedHashMap<>();
 
     private Table<Integer, String, Integer> personTable = HashBasedTable.create();
     private Table<Integer, String, Integer> householdTable = HashBasedTable.create();

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/germany/preparation/ReadZonalData.java
@@ -46,7 +46,7 @@ public class ReadZonalData {
         //List of municipalities and counties that are used for IPU and allocation
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         ArrayList<Integer> municipalitiesWithZero = new ArrayList<>();
         for (int row = 1; row <= PropertiesSynPop.get().main.selectedMunicipalities.getRowCount(); row++) {
             if (PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "Select") == 1f) {
@@ -77,7 +77,7 @@ public class ReadZonalData {
         dataSetSynPop.setMunicipalitiesWithZeroPopulation(municipalitiesWithZero);
 
         if (PropertiesSynPop.get().main.boroughIPU) {
-            HashMap<Integer, ArrayList> boroughsByCounty = new HashMap<>();
+            HashMap<Integer, ArrayList> boroughsByCounty = new LinkedHashMap<>();
             ArrayList<Integer> boroughs = new ArrayList<>();
             ArrayList<Integer> countieswithBoroughs = new ArrayList<>();
             for (int row = 1; row <= PropertiesSynPop.get().main.selectedBoroughs.getRowCount(); row++) {
@@ -106,11 +106,11 @@ public class ReadZonalData {
     private void readZones(){
         //TAZ attributes
         logger.info("   Started to read TAZ 100 by 100 m");
-        HashMap<Integer, int[]> cityTAZ = new HashMap<>();
-        Map<Integer, Map<Integer, Float>> probabilityZone = new HashMap<>();
+        HashMap<Integer, int[]> cityTAZ = new LinkedHashMap<>();
+        Map<Integer, Map<Integer, Float>> probabilityZone = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = HashBasedTable.create();
         Table<Integer, String, Integer> zoneCoordinates = HashBasedTable.create();
-        Map<Integer, Integer> universityByZone = new HashMap<>();
+        Map<Integer, Integer> universityByZone = new LinkedHashMap<>();
         ArrayList<Integer> tazs = new ArrayList<>();
         TableDataSet zoneAttributes;
         if (!PropertiesSynPop.get().main.boroughIPU){
@@ -139,7 +139,7 @@ public class ReadZonalData {
             } else {
                 int[] previousTaz = {taz};
                 cityTAZ.put(city,previousTaz);
-                Map<Integer, Float> probabilities = new HashMap<>();
+                Map<Integer, Float> probabilities = new LinkedHashMap<>();
                 probabilities.put(taz, probability);
                 probabilityZone.put(city, probabilities);
             }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/ExtractMicroDataJP.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/ExtractMicroDataJP.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -170,7 +171,7 @@ public class ExtractMicroDataJP {
     private void setAttributesToCopyFromMicroData() {
         //method to set the attributesControlTotal to read
 
-        attributesMicroData = new HashMap<>();
+        attributesMicroData = new LinkedHashMap<>();
         for (int i = 1; i <= variables.getRowCount(); i++){
             String key = variables.getStringValueAt(i,"Type");
             String value = variables.getStringValueAt(i,"VariableNameMicroData");
@@ -396,7 +397,7 @@ public class ExtractMicroDataJP {
         frequencyMatrix = new TableDataSet();
         frequencyMatrix.appendColumn(microHouseholds.getColumnAsInt("id"),"id");
 
-        attributesDictionary = new HashMap<>();
+        attributesDictionary = new LinkedHashMap<>();
 
         for (int i = 0; i < attributesControlTotal.length; i++){
             int finish = 0;
@@ -793,10 +794,10 @@ public class ExtractMicroDataJP {
         SiloUtil.addIntegerColumnToTableDataSet(microDataPerson, "rearrangedRole");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold,"nonClassifiedMales");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold, "nonClassifiedFemales"*//*);*/
-        childrenInHousehold = new HashMap<>();
-        noClass = new HashMap<>();
-        singles = new HashMap<>();
-        married = new HashMap<>();
+        childrenInHousehold = new LinkedHashMap<>();
+        noClass = new LinkedHashMap<>();
+        singles = new LinkedHashMap<>();
+        married = new LinkedHashMap<>();
     }
 
 
@@ -815,7 +816,7 @@ public class ExtractMicroDataJP {
         }
         HashMap<Integer, Integer> inner = outer.get(key);
         if (inner == null){
-            inner = new HashMap<Integer, Integer>();
+            inner = new LinkedHashMap<Integer, Integer>();
             outer.put(key, inner);
         }
         inner.put(row, age);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/IPUbyCityWithSubsample.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/IPUbyCityWithSubsample.java
@@ -200,11 +200,11 @@ public class IPUbyCityWithSubsample {
         startTime = System.nanoTime();
 
         //weights, values, control totals
-        weightsByMun = Collections.synchronizedMap(new HashMap<>());
-        minWeightsByMun = Collections.synchronizedMap(new HashMap<>());
-        valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-        totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-        errorsByMunicipality = Collections.synchronizedMap(new HashMap<>());
+        weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        minWeightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorsByMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
 
 
         finish = 0;
@@ -240,7 +240,7 @@ public class IPUbyCityWithSubsample {
                 errorsByMunicipality.put(attribute, 0.);
 
             } else {
-                HashMap<String, Integer> inner = new HashMap<>();
+                HashMap<String, Integer> inner = new LinkedHashMap<>();
                 inner.put(attribute, (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, attribute));
                 totalMunicipality.put(municipality, inner);
                 errorsByMunicipality.put(attribute, 0.);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/SyntheticPopJP.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/kagawa/SyntheticPopJP.java
@@ -130,7 +130,7 @@ public class SyntheticPopJP implements SyntheticPopI {
     protected TableDataSet odCountyFlow;
     private DataContainer dataContainer;
 
-    private HashMap<Person, Integer> jobTypeByWorker= new HashMap<>();
+    private HashMap<Person, Integer> jobTypeByWorker= new LinkedHashMap<>();
 
     static Logger logger = LogManager.getLogger(String.valueOf(SyntheticPopJP.class));
     private Properties properties;
@@ -202,7 +202,7 @@ public class SyntheticPopJP implements SyntheticPopI {
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
         HashMap<Integer, ArrayList> municipalitiesByCounty;
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         for (int row = 1; row <= selectedMunicipalities.getRowCount(); row++){
             if (selectedMunicipalities.getValueAt(row,"Select") == 1f){
                 int city = (int) selectedMunicipalities.getValueAt(row,"V1");
@@ -237,7 +237,7 @@ public class SyntheticPopJP implements SyntheticPopI {
         //TAZ attributes
         cellsMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_RASTER_CELLS));
         cellsMatrix.buildIndex(cellsMatrix.getColumnPosition("ID_cell"));
-        cityTAZ = new HashMap<>();
+        cityTAZ = new LinkedHashMap<>();
         for (int i = 1; i <= cellsMatrix.getRowCount(); i++){
             int city = (int) cellsMatrix.getValueAt(i,"ID_city");
             int taz = (int) cellsMatrix.getValueAt(i,"ID_cell");
@@ -280,14 +280,14 @@ public class SyntheticPopJP implements SyntheticPopI {
         regionsforFrequencyMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_ATRIBUTES_ZONAL_DATA));
         regionsforFrequencyMatrix.buildIndex(regionsforFrequencyMatrix.getColumnPosition("V1"));
 
-        householdsForFrequencyMatrix = new HashMap<>();
+        householdsForFrequencyMatrix = new LinkedHashMap<>();
         for (int i = 1; i <= microDataDwelling.getRowCount();i++){
             int v2Zone = (int) microDataDwelling.getValueAt(i,"PtResCode");
             int ddID = (int) microDataDwelling.getValueAt(i,"id");
             if (householdsForFrequencyMatrix.containsKey(v2Zone)) {
                 householdsForFrequencyMatrix.get(v2Zone).put(ddID, 1);
             } else {
-                HashMap<Integer, Integer> map = new HashMap<>();
+                HashMap<Integer, Integer> map = new LinkedHashMap<>();
                 map.put(ddID, 1);
                 householdsForFrequencyMatrix.put(v2Zone, map);
             }
@@ -318,14 +318,14 @@ public class SyntheticPopJP implements SyntheticPopI {
         regionsforFrequencyMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_ATRIBUTES_ZONAL_DATA));
         regionsforFrequencyMatrix.buildIndex(regionsforFrequencyMatrix.getColumnPosition("V1"));
 
-        householdsForFrequencyMatrix = new HashMap<>();
+        householdsForFrequencyMatrix = new LinkedHashMap<>();
         for (int i = 1; i <= microDataDwelling.getRowCount();i++){
             int v2Zone = (int) microDataDwelling.getValueAt(i,"PtResCode");
             int ddID = (int) microDataDwelling.getValueAt(i,"id");
             if (householdsForFrequencyMatrix.containsKey(v2Zone)) {
                 householdsForFrequencyMatrix.get(v2Zone).put(ddID, 1);
             } else {
-                HashMap<Integer, Integer> map = new HashMap<>();
+                HashMap<Integer, Integer> map = new LinkedHashMap<>();
                 map.put(ddID, 1);
                 householdsForFrequencyMatrix.put(v2Zone, map);
             }
@@ -1037,7 +1037,7 @@ public class SyntheticPopJP implements SyntheticPopI {
 
 
         //Create a map to store the household IDs by municipality
-        HashMap<Integer, HashMap<Integer, Integer>> householdByMunicipality = new HashMap<>();
+        HashMap<Integer, HashMap<Integer, Integer>> householdByMunicipality = new LinkedHashMap<>();
 
         generateCountersForValidation();
 
@@ -1047,14 +1047,14 @@ public class SyntheticPopJP implements SyntheticPopI {
 
         regionsforFrequencyMatrix = SiloUtil.readCSVfile(rb.getString(PROPERTIES_ATRIBUTES_ZONAL_DATA));
         regionsforFrequencyMatrix.buildIndex(regionsforFrequencyMatrix.getColumnPosition("V1"));
-        householdsForFrequencyMatrix = new HashMap<>();
+        householdsForFrequencyMatrix = new LinkedHashMap<>();
         for (int i = 1; i <= microDataDwelling.getRowCount();i++){
             int v2Zone = (int) microDataDwelling.getValueAt(i,"PtResCode");
             int ddID = (int) microDataDwelling.getValueAt(i,"id");
             if (householdsForFrequencyMatrix.containsKey(v2Zone)) {
                 householdsForFrequencyMatrix.get(v2Zone).put(ddID, 1);
             } else {
-                HashMap<Integer, Integer> map = new HashMap<>();
+                HashMap<Integer, Integer> map = new LinkedHashMap<>();
                 map.put(ddID, 1);
                 householdsForFrequencyMatrix.put(v2Zone, map);
             }
@@ -1104,7 +1104,7 @@ public class SyntheticPopJP implements SyntheticPopI {
 
                 HashMap<Integer, Integer> hhs = householdsForFrequencyMatrix.get(v2zone);
                 int[] hhFromV2 = hhs.keySet().stream().mapToInt(Integer::intValue).toArray();
-                HashMap<Integer, Integer> generatedHouseholds = new HashMap<>();
+                HashMap<Integer, Integer> generatedHouseholds = new LinkedHashMap<>();
 
 
                 //obtain the raster cells of the municipality and their weight within the municipality
@@ -1118,7 +1118,7 @@ public class SyntheticPopJP implements SyntheticPopI {
 
 
                 double hhRemaining = 0;
-                HashMap<Integer, Double> prob = new HashMap<>();
+                HashMap<Integer, Double> prob = new LinkedHashMap<>();
                 for (int row = 0; row < hhFromV2.length; row++){
                     double value = weightsTable.getIndexedValueAt(hhFromV2[row], Integer.toString(municipalityID));
                     hhRemaining = hhRemaining + value;
@@ -1592,12 +1592,12 @@ public class SyntheticPopJP implements SyntheticPopI {
         logger.info("  Identifying vacant jobs by zone");
         Collection<Job> jobs = dataContainer.getJobDataManager().getJobs();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
-        jobIntTypes = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < jobStringTypes.length; i++) {
             jobIntTypes.put(jobStringTypes[i], i);
         }
@@ -1665,10 +1665,10 @@ public class SyntheticPopJP implements SyntheticPopI {
     private void identifyVacantSchoolsByZoneByType(){
         logger.info("   Create vacant schools");
 
-        numberVacantSchoolsByZoneByType = new HashMap<>();
-        numberZonesWithVacantSchoolsByType = new HashMap<>();
-        idZonesVacantSchoolsByType = new HashMap<>();
-        schoolCapacityByType = new HashMap<>();
+        numberVacantSchoolsByZoneByType = new LinkedHashMap<>();
+        numberZonesWithVacantSchoolsByType = new LinkedHashMap<>();
+        idZonesVacantSchoolsByType = new LinkedHashMap<>();
+        schoolCapacityByType = new LinkedHashMap<>();
         schoolTypes = ResourceUtil.getIntegerArray(rb, PROPERTIES_SCHOOL_TYPES_DE);
         int[] cellsID = cellsMatrix.getColumnAsInt("ID_cell");
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/DataSetSynPopMCR.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/DataSetSynPopMCR.java
@@ -15,6 +15,7 @@ import org.locationtech.jts.geom.Coordinate;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -44,7 +45,7 @@ public class DataSetSynPopMCR extends DataSetSynPop {
     private int[] countyIDs;
     private int[] tazIDs;
     private Map<Integer, Map<Integer, Float>> probabilityZone;
-    private Map<Integer, Map<ManchesterDwellingTypes.DwellingTypeManchester, Map<Integer, Float>>> probabilityZoneByDdType = new HashMap<>();
+    private Map<Integer, Map<ManchesterDwellingTypes.DwellingTypeManchester, Map<Integer, Float>>> probabilityZoneByDdType = new LinkedHashMap<>();
 
     private Map<Integer, Map<DwellingType, Integer>> dwellingPriceByTypeAndZone;
     private Table<Integer, Integer, Integer> schoolCapacity = HashBasedTable.create();

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/Allocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/Allocation.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class Allocation extends ModuleSynPop{
 
@@ -57,7 +58,7 @@ public class Allocation extends ModuleSynPop{
     }
 
     public void generateHouseholdsPersonsDwellings(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new GenerateHouseholdsPersonsDwellings(dataContainer, dataSetSynPop, educationalLevel).run();
     }
 
@@ -76,7 +77,7 @@ public class Allocation extends ModuleSynPop{
     public void generateAutos() {new CarOwnership(dataContainer, dataSetSynPop).run();}
 
     public void readPopulation(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new ReadPopulation(dataContainer, educationalLevel).run();
     }
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/AssignJobs.java
@@ -167,18 +167,18 @@ public class AssignJobs {
         Collection<Job> jobs = dataContainer.getJobDataManager().getJobs();
 
         jobStringTypes = PropertiesSynPop.get().main.jobStringType;
-        jobIntTypes = new HashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }
         tazIds = dataSetSynPop.getTazs().stream().mapToInt(i -> i).toArray();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
-        jobIntTypes = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/AssignSchools.java
@@ -36,7 +36,7 @@ public class AssignSchools {
     private Map<Integer, Map<Integer,Integer>> schoolCapacityMap;
     private Map<Integer, Integer> numberOfVacantPlacesByType;
 
-    Map<Integer,Map<Integer,Map<Integer,Integer>>> schoolByZoneByType = new HashMap<>();
+    Map<Integer,Map<Integer,Map<Integer,Integer>>> schoolByZoneByType = new LinkedHashMap<>();
 
 
     public AssignSchools(DataContainerWithSchools dataContainer, DataSetSynPop dataSetSynPop){
@@ -110,7 +110,7 @@ public class AssignSchools {
 
         int schooltaz = -2;
         if (numberOfVacantPlacesByType.get(3) > 0) {
-            Map<Integer, Float> probability = new HashMap<>();
+            Map<Integer, Float> probability = new LinkedHashMap<>();
             Iterator<Integer> iterator = schoolCapacityMap.get(3).keySet().iterator();
             while (iterator.hasNext()) {
                 Integer zone = iterator.next();
@@ -176,8 +176,8 @@ public class AssignSchools {
 
     private void initializeSchoolCapacity(){
 
-        schoolCapacityMap = new HashMap<>();
-        numberOfVacantPlacesByType = new HashMap<>();
+        schoolCapacityMap = new LinkedHashMap<>();
+        numberOfVacantPlacesByType = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = dataSetSynPop.getSchoolCapacity();
         Iterator<Integer> iteratorRow = schoolCapacity.rowKeySet().iterator();
         while (iteratorRow.hasNext()){
@@ -187,7 +187,7 @@ public class AssignSchools {
                 int schoolType = iteratorCol.next();
                 int places = schoolCapacity.get(zone, schoolType);
                 if (places > 0) {
-                    Map<Integer, Integer> prevPlaces = new HashMap<>();
+                    Map<Integer, Integer> prevPlaces = new LinkedHashMap<>();
                     if (schoolCapacityMap.get(schoolType)!= null) {
                         prevPlaces = schoolCapacityMap.get(schoolType);
                     }
@@ -274,8 +274,8 @@ public class AssignSchools {
             Coordinate coordinate = new Coordinate(xCoordinate,yCoordinate);
             schoolData.addSchool(SchoolUtils.getFactory().createSchool(id, schoolType, schoolCapacity,0,coordinate, zone));
 
-            schoolByZoneByType.computeIfAbsent(zone, k -> new HashMap<>())
-                    .computeIfAbsent(schoolType, k -> new HashMap<>())
+            schoolByZoneByType.computeIfAbsent(zone, k -> new LinkedHashMap<>())
+                    .computeIfAbsent(schoolType, k -> new LinkedHashMap<>())
                     .put(id, schoolCapacity);
 
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateHouseholdsPersonsDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateHouseholdsPersonsDwellings.java
@@ -287,7 +287,7 @@ public class GenerateHouseholdsPersonsDwellings {
 
         totalHouseholds = (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "hh");
 
-        probMicroData = new HashMap<>();
+        probMicroData = new LinkedHashMap<>();
         probabilityId = new double[dataSetSynPop.getWeights().getRowCount()];
         ids = new int[probabilityId.length];
         sumProbabilities = 0;
@@ -467,9 +467,9 @@ public class GenerateHouseholdsPersonsDwellings {
 
 
     private void summaryByCity(int municipality) {
-        Map<Integer, Household> householdMap = new HashMap<>();
-        Map<Integer, Dwelling> dwellingMap = new HashMap<>();
-        Map<Integer, Person> personMap = new HashMap<>();
+        Map<Integer, Household> householdMap = new LinkedHashMap<>();
+        Map<Integer, Dwelling> dwellingMap = new LinkedHashMap<>();
+        Map<Integer, Person> personMap = new LinkedHashMap<>();
         int ppNumber = 0;
         for (int hhNumber = 0; hhNumber < totalHouseholds; hhNumber++){
             Household hh = householdData.getHouseholdFromId(hhNumber + firstHouseholdMunicipality);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateJobs.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobs {
@@ -64,7 +65,7 @@ public class GenerateJobs {
 
 
     private void initializeTAZprobability(int municipality, String jobType){
-        jobsByTaz = new HashMap<>();
+        jobsByTaz = new LinkedHashMap<>();
         jobsByTaz.clear();
         for (int taz : dataSetSynPop.getTazByMunicipality().get(municipality)){
             jobsByTaz.put(taz, dataSetSynPop.getTazAttributes().get(taz).get(jobType));

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateVacantDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/allocation/GenerateVacantDwellings.java
@@ -31,7 +31,7 @@ public class GenerateVacantDwellings {
     private int highestDwellingIdInUse;
     private final DataContainer dataContainer;
     private RealEstateDataManager realEstateData;
-    private Map<Integer, List<Dwelling>> occupiedDwellings = new HashMap<>();
+    private Map<Integer, List<Dwelling>> occupiedDwellings = new LinkedHashMap<>();
     private DwellingFactory dwellingFactory;
 
 
@@ -108,11 +108,11 @@ public class GenerateVacantDwellings {
 
     private void initializeVacantDwellingData(int municipality){
 
-        probVacantFloor = new HashMap<>();
+        probVacantFloor = new LinkedHashMap<>();
         for (int floor : PropertiesSynPop.get().main.sizeBracketsDwelling) {
             probVacantFloor.put(floor, PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "vacantDwellings" + floor));
         }
-        probVacantBuildingSize = new HashMap<>();
+        probVacantBuildingSize = new LinkedHashMap<>();
         for (int year : PropertiesSynPop.get().main.yearBracketsDwelling){
             int sizeYear = year;
             String label = "vacantSmallDwellings" + year;
@@ -149,13 +149,13 @@ public class GenerateVacantDwellings {
                 }
                 ddQuality.put(key, qualities);
             } else {
-                Map<Integer, Float> qualities = new HashMap<>();
+                Map<Integer, Float> qualities = new LinkedHashMap<>();
                 qualities.put(quality, 1f);
                 ddQuality.put(key, qualities);
             }
         } else {
-            ddQuality = new HashMap<>();
-            Map<Integer, Float> qualities = new HashMap<>();
+            ddQuality = new LinkedHashMap<>();
+            Map<Integer, Float> qualities = new LinkedHashMap<>();
             qualities.put(quality, 1f);
             ddQuality.put(key, qualities);
         }
@@ -228,7 +228,7 @@ public class GenerateVacantDwellings {
     private int selectQualityVacant(int municipality, int year){
         int result = 0;
         if (ddQuality.get(year * 10000000 + municipality) == null) {
-            HashMap<Integer, Float> qualities = new HashMap<>();
+            HashMap<Integer, Float> qualities = new LinkedHashMap<>();
             for (int quality = 1; quality <= PropertiesSynPop.get().main.numberofQualityLevels; quality++){
                 qualities.put(quality, 1f);
             }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateDwellingMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateDwellingMicrolocation.java
@@ -23,9 +23,9 @@ public class GenerateDwellingMicrolocation {
     private static final Logger logger = LogManager.getLogger(GenerateDwellingMicrolocation.class);
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private final Map<Long, Coordinate> buildingCoord = new HashMap<>();
-    private final Map<Integer, Map<String, List<Long>>> zone2ddType2buildingIdMap = new HashMap<>();
-    Map<Long, Integer> buildingZone = new HashMap<>();
+    private final Map<Long, Coordinate> buildingCoord = new LinkedHashMap<>();
+    private final Map<Integer, Map<String, List<Long>>> zone2ddType2buildingIdMap = new LinkedHashMap<>();
+    Map<Long, Integer> buildingZone = new LinkedHashMap<>();
 
     public GenerateDwellingMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataContainer = dataContainer;
@@ -181,7 +181,7 @@ public class GenerateDwellingMicrolocation {
                 buildingZone.put(id,zone);
                 //put all buildings with the same zoneID into one building list
                 zone2ddType2buildingIdMap.computeIfAbsent(zone, k -> {
-                    Map<String, List<Long>> typeMap = new HashMap<>();
+                    Map<String, List<Long>> typeMap = new LinkedHashMap<>();
                     for (ManchesterDwellingTypes.DwellingTypeManchester type : ManchesterDwellingTypes.DwellingTypeManchester.values()) {
                         typeMap.put(type.toString(), new ArrayList<>());
                     }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateJobMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateJobMicrolocation.java
@@ -25,9 +25,9 @@ public class GenerateJobMicrolocation {
     
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private final Map<Integer, Coordinate> jobCoord = new HashMap<>();
-    private final Map<Integer, Map<Integer, Double>> zone2JobId2WeightMap = new HashMap<>();
-    private final Map<Integer, Double> zoneLocationJobFactor = new HashMap<>();
+    private final Map<Integer, Coordinate> jobCoord = new LinkedHashMap<>();
+    private final Map<Integer, Map<Integer, Double>> zone2JobId2WeightMap = new LinkedHashMap<>();
+    private final Map<Integer, Double> zoneLocationJobFactor = new LinkedHashMap<>();
 
     public GenerateJobMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataSetSynPop = dataSetSynPop;
@@ -73,7 +73,7 @@ public class GenerateJobMicrolocation {
     private void calculateLocationJobFactor() {
 
         //total jobs in zone
-        Map<Integer, Integer> zoneJobCounts = new HashMap<>();
+        Map<Integer, Integer> zoneJobCounts = new LinkedHashMap<>();
         for(Job jj : dataContainer.getJobDataManager().getJobs()){
             zoneJobCounts.merge(jj.getZoneId(), 1, Integer::sum);
         }
@@ -153,7 +153,7 @@ public class GenerateJobMicrolocation {
 
                 jobCoord.put(id,coordinate);
                 //put all buildings with the same zoneID into one building list
-                zone2JobId2WeightMap.computeIfAbsent(zone, k -> new HashMap<>()).put(id, weight);
+                zone2JobId2WeightMap.computeIfAbsent(zone, k -> new LinkedHashMap<>()).put(id, weight);
 
             }
             if(noCoordCounter > 0) {

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateSchoolMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/microlocation/GenerateSchoolMicrolocation.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateSchoolMicrolocation {
@@ -24,7 +25,7 @@ public class GenerateSchoolMicrolocation {
 
     private final DataContainerWithSchools dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new HashMap<>();
+    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new LinkedHashMap<>();
 
 
     public GenerateSchoolMicrolocation(DataContainerWithSchools dataContainer, DataSetSynPop dataSetSynPop){
@@ -74,9 +75,9 @@ public class GenerateSchoolMicrolocation {
     private void createSchools() {
 
         for (int zone : dataSetSynPop.getTazs()){
-            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new HashMap<>();
+            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new LinkedHashMap<>();
             for (int type = 1 ; type <= 3; type++){
-                Map<Integer,Integer> schoolCapacity = new HashMap<>();
+                Map<Integer,Integer> schoolCapacity = new LinkedHashMap<>();
                 schoolLocationListForThisSchoolType.put(type,schoolCapacity);
             }
             zoneSchoolTypeSchoolLocationCapacity.put(zone,schoolLocationListForThisSchoolType);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/CheckHouseholdRelationship.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/CheckHouseholdRelationship.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CheckHouseholdRelationship {
@@ -322,10 +323,10 @@ public class CheckHouseholdRelationship {
         SiloUtil.addIntegerColumnToTableDataSet(microDataPerson, "rearrangedRole");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold,"nonClassifiedMales");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold, "nonClassifiedFemales"*//*);*/
-        childrenInHousehold = new HashMap<>();
-        noClass = new HashMap<>();
-        singles = new HashMap<>();
-        married = new HashMap<>();
+        childrenInHousehold = new LinkedHashMap<>();
+        noClass = new LinkedHashMap<>();
+        singles = new LinkedHashMap<>();
+        married = new LinkedHashMap<>();
     }
 
 
@@ -344,7 +345,7 @@ public class CheckHouseholdRelationship {
         }
         HashMap<Integer, Integer> inner = outer.get(key);
         if (inner == null){
-            inner = new HashMap<Integer, Integer>();
+            inner = new LinkedHashMap<Integer, Integer>();
             outer.put(key, inner);
         }
         inner.put(row, age);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/MicroDataManager.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/MicroDataManager.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MicroDataManager {
@@ -26,7 +27,7 @@ public class MicroDataManager {
 
     public HashMap<String, String[]> attributesMicroData(){
 
-        HashMap<String, String[]> attributesMicroData = new HashMap<>();
+        HashMap<String, String[]> attributesMicroData = new LinkedHashMap<>();
         String[] attributesPerson = {"age", "gender", "occupation", "income", "nationality", "telework", "ppPrivate", "educationDegree", "personStatus", "spouseInHousehold", "marriage", "relationship", "school"};
         String[] attributesHousehold = {"workers", "hhSize"};
         String[] attributesDwelling = {"ddUse", "ddYear", "ddFloor", "ddSize", "ddHeatingEnergy", "ddHeatingType", "ddAdHeating"};
@@ -39,62 +40,62 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesPersonMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> age = new HashMap<>();
+            Map<String, Integer> age = new LinkedHashMap<>();
                 age.put("initial", 50);
                 age.put("end", 52);
                 attributesIPU.put("age", age);
-            Map<String, Integer> gender = new HashMap<>();
+            Map<String, Integer> gender = new LinkedHashMap<>();
                 gender.put("initial", 54);
                 gender.put("end", 55);
                 attributesIPU.put("gender", gender);
-            Map<String, Integer> occupation = new HashMap<>();
+            Map<String, Integer> occupation = new LinkedHashMap<>();
                 occupation.put("initial", 32);
                 occupation.put("end", 33);
                 attributesIPU.put("occupation", occupation);
-            Map<String, Integer> nationality = new HashMap<>();
+            Map<String, Integer> nationality = new LinkedHashMap<>();
                 nationality.put("initial", 370);
                 nationality.put("end", 372);
                 attributesIPU.put("nationality", nationality);
         //Additional attributes
-            Map<String, Integer> income = new HashMap<>();
+            Map<String, Integer> income = new LinkedHashMap<>();
                 income.put("initial", 471);
                 income.put("end", 473);
                 attributesIPU.put("income", income);
-            Map<String, Integer> telework = new HashMap<>();
+            Map<String, Integer> telework = new LinkedHashMap<>();
                 telework.put("initial", 198);
                 telework.put("end", 200);
                 attributesIPU.put("telework", telework);
-            Map<String, Integer> ppPrivate = new HashMap<>();
+            Map<String, Integer> ppPrivate = new LinkedHashMap<>();
                 ppPrivate.put("initial", 34);
                 ppPrivate.put("end", 35);
                 attributesIPU.put("ppPrivate", ppPrivate);
-            Map<String, Integer> educationDegree = new HashMap<>();
+            Map<String, Integer> educationDegree = new LinkedHashMap<>();
                 educationDegree.put("initial", 323);
                 educationDegree.put("end", 325);
                 attributesIPU.put("educationDegree", educationDegree);
-            Map<String, Integer> status = new HashMap<>();
+            Map<String, Integer> status = new LinkedHashMap<>();
                 status.put("initial", 40);
                 status.put("end", 42);
                 attributesIPU.put("personStatus", status);
-            Map<String, Integer> spouse = new HashMap<>();
+            Map<String, Integer> spouse = new LinkedHashMap<>();
                 spouse.put("initial", 36);
                 spouse.put("end", 38);
                 attributesIPU.put("spouseInHousehold", spouse);
-            Map<String, Integer> marriage = new HashMap<>();
+            Map<String, Integer> marriage = new LinkedHashMap<>();
                 marriage.put("initial", 59);
                 marriage.put("end", 60);
                 attributesIPU.put("marriage", marriage);
-            Map<String, Integer> relationship = new HashMap<>();
+            Map<String, Integer> relationship = new LinkedHashMap<>();
                 relationship.put("initial", 566);
                 relationship.put("end", 568);
                 attributesIPU.put("relationship", relationship);
-            Map<String, Integer> school = new HashMap<>();
+            Map<String, Integer> school = new LinkedHashMap<>();
                 school.put("initial", 307);
                 school.put("end", 309);
                 attributesIPU.put("school", school);
-            Map<String, Integer> disability = new HashMap<>();
+            Map<String, Integer> disability = new LinkedHashMap<>();
                 disability.put("initial", 237);
                 disability.put("end", 239);
                 attributesIPU.put("disability", disability);
@@ -104,14 +105,14 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesHouseholdMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> hhSize = new HashMap<>();
+            Map<String, Integer> hhSize = new LinkedHashMap<>();
                 hhSize.put("initial", 26);
                 hhSize.put("end", 28);
                 attributesIPU.put("hhSize", hhSize);
         //Additional attributes
-            Map<String, Integer> workers = new HashMap<>();
+            Map<String, Integer> workers = new LinkedHashMap<>();
                 workers.put("initial", 572);
                 workers.put("end", 574);
                 attributesIPU.put("workers", workers);
@@ -121,34 +122,34 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesDwellingMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> ddUse = new HashMap<>();
+            Map<String, Integer> ddUse = new LinkedHashMap<>();
                 ddUse.put("initial", 493);
                 ddUse.put("end", 495);
                 attributesIPU.put("ddUse", ddUse);
-            Map<String, Integer> ddYear = new HashMap<>();
+            Map<String, Integer> ddYear = new LinkedHashMap<>();
                 ddYear.put("initial", 500);
                 ddYear.put("end", 502);
                 attributesIPU.put("ddYear", ddYear);
-            Map<String, Integer> ddFloor = new HashMap<>();
+            Map<String, Integer> ddFloor = new LinkedHashMap<>();
                 ddFloor.put("initial", 495);
                 ddFloor.put("end", 498);
                 attributesIPU.put("ddFloor", ddFloor);
-            Map<String, Integer> ddSize = new HashMap<>();
+            Map<String, Integer> ddSize = new LinkedHashMap<>();
                 ddSize.put("initial", 491);
                 ddSize.put("end", 493);
                 attributesIPU.put("ddSize", ddSize);
         //Additional attributes
-            Map<String, Integer> ddHeatingEnergy = new HashMap<>();
+            Map<String, Integer> ddHeatingEnergy = new LinkedHashMap<>();
                 ddHeatingEnergy.put("initial", 506);
                 ddHeatingEnergy.put("end", 508);
                 attributesIPU.put("ddHeatingEnergy", ddHeatingEnergy);
-            Map<String, Integer> ddHeatingType = new HashMap<>();
+            Map<String, Integer> ddHeatingType = new LinkedHashMap<>();
                 ddHeatingType.put("initial", 504);
                 ddHeatingType.put("end", 506);
                 attributesIPU.put("ddHeatingType", ddHeatingType);
-            Map<String, Integer> ddAdHeating = new HashMap<>();
+            Map<String, Integer> ddAdHeating = new LinkedHashMap<>();
                 ddAdHeating.put("initial", 1017);
                 ddAdHeating.put("end", 1019);
                 attributesIPU.put("ddAdHeating", ddAdHeating);
@@ -157,108 +158,108 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> exceptionsMicroData(){
 
-        Map<String, Map<String, Integer>> exceptionsMicroData = new HashMap<>();
-            Map<String, Integer> LivingInQuarter = new HashMap<>();
+        Map<String, Map<String, Integer>> exceptionsMicroData = new LinkedHashMap<>();
+            Map<String, Integer> LivingInQuarter = new LinkedHashMap<>();
                 LivingInQuarter.put("initial", 34);
                 LivingInQuarter.put("end", 35);
                 LivingInQuarter.put("exceptionIf", 2);
                 exceptionsMicroData.put("quarter", LivingInQuarter);
-            Map<String, Integer> noIncome = new HashMap<>();
+            Map<String, Integer> noIncome = new LinkedHashMap<>();
                 noIncome.put("initial", 658);
                 noIncome.put("end", 660);
                 noIncome.put("exceptionIf", 99);
                 exceptionsMicroData.put("noIncome", noIncome);
-            Map<String, Integer> movingOutInFiveYears = new HashMap<>();
+            Map<String, Integer> movingOutInFiveYears = new LinkedHashMap<>();
                 movingOutInFiveYears.put("initial", 491);
                 movingOutInFiveYears.put("end", 493);
                 movingOutInFiveYears.put("exceptionIf", -5);
                 exceptionsMicroData.put("movedOut", movingOutInFiveYears);
-            Map<String, Integer> noBuildingSize = new HashMap<>();
+            Map<String, Integer> noBuildingSize = new LinkedHashMap<>();
                 noBuildingSize.put("initial", 491);
                 noBuildingSize.put("end", 493);
                 noBuildingSize.put("exceptionIf", 9);
                 exceptionsMicroData.put("noSize", noBuildingSize);
-            Map<String, Integer> noDwellingUsage = new HashMap<>();
+            Map<String, Integer> noDwellingUsage = new LinkedHashMap<>();
                 noDwellingUsage.put("initial", 493);
                 noDwellingUsage.put("end", 495);
                 noDwellingUsage.put("exceptionIf", 9);
                 exceptionsMicroData.put("noUsage", noDwellingUsage);
-            Map<String, Integer> noBuildingYear = new HashMap<>();
+            Map<String, Integer> noBuildingYear = new LinkedHashMap<>();
                 noBuildingYear.put("initial", 500);
                 noBuildingYear.put("end", 502);
                 noBuildingYear.put("exceptionIf", 99);
                 exceptionsMicroData.put("noYear", noBuildingYear);
-            Map<String, Integer> SchleswigHolstein = new HashMap<>();
+            Map<String, Integer> SchleswigHolstein = new LinkedHashMap<>();
                 SchleswigHolstein.put("initial", 0);
                 SchleswigHolstein.put("end", 2);
                 SchleswigHolstein.put("exceptionIf", 1);
                 exceptionsMicroData.put("out1", SchleswigHolstein);
-            Map<String, Integer> Hamburg = new HashMap<>();
+            Map<String, Integer> Hamburg = new LinkedHashMap<>();
                 Hamburg.put("initial", 0);
                 Hamburg.put("end", 2);
                 Hamburg.put("exceptionIf", 2);
                 exceptionsMicroData.put("out2", Hamburg);
-            Map<String, Integer> Niedersachsen = new HashMap<>();
+            Map<String, Integer> Niedersachsen = new LinkedHashMap<>();
                 Niedersachsen.put("initial", 0);
                 Niedersachsen.put("end", 2);
                 Niedersachsen.put("exceptionIf", 3);
                 exceptionsMicroData.put("out3", Niedersachsen);
-            Map<String, Integer> Bremen = new HashMap<>();
+            Map<String, Integer> Bremen = new LinkedHashMap<>();
                 Bremen.put("initial", 0);
                 Bremen.put("end", 2);
                 Bremen.put("exceptionIf", 4);
                 exceptionsMicroData.put("out4", Bremen);
-            Map<String, Integer> NordrheinWestfalen = new HashMap<>();
+            Map<String, Integer> NordrheinWestfalen = new LinkedHashMap<>();
                 NordrheinWestfalen.put("initial", 0);
                 NordrheinWestfalen.put("end", 2);
                 NordrheinWestfalen.put("exceptionIf", 5);
                 exceptionsMicroData.put("out5", NordrheinWestfalen);
-            Map<String, Integer> Hessen = new HashMap<>();
+            Map<String, Integer> Hessen = new LinkedHashMap<>();
                 Hessen.put("initial", 0);
                 Hessen.put("end", 2);
                 Hessen.put("exceptionIf", 6);
                 exceptionsMicroData.put("out6", Hessen);
-            Map<String, Integer> RheinlandPfalz = new HashMap<>();
+            Map<String, Integer> RheinlandPfalz = new LinkedHashMap<>();
                 RheinlandPfalz.put("initial", 0);
                 RheinlandPfalz.put("end", 2);
                 RheinlandPfalz.put("exceptionIf", 7);
                 exceptionsMicroData.put("out7", RheinlandPfalz);
-            Map<String, Integer> BadenWuerttemberg = new HashMap<>();
+            Map<String, Integer> BadenWuerttemberg = new LinkedHashMap<>();
                 BadenWuerttemberg.put("initial", 0);
                 BadenWuerttemberg.put("end", 2);
                 BadenWuerttemberg.put("exceptionIf", 8);
                 exceptionsMicroData.put("out8", BadenWuerttemberg);
-            Map<String, Integer> Saarland = new HashMap<>();
+            Map<String, Integer> Saarland = new LinkedHashMap<>();
                 Saarland.put("initial", 0);
                 Saarland.put("end", 2);
                 Saarland.put("exceptionIf", 10);
                 exceptionsMicroData.put("out10", Saarland);
-            Map<String, Integer> Berlin = new HashMap<>();
+            Map<String, Integer> Berlin = new LinkedHashMap<>();
                 Berlin.put("initial", 0);
                 Berlin.put("end", 2);
                 Berlin.put("exceptionIf", 11);
                 exceptionsMicroData.put("out11", Berlin);
-            Map<String, Integer> Brandenburg = new HashMap<>();
+            Map<String, Integer> Brandenburg = new LinkedHashMap<>();
                 Brandenburg.put("initial", 0);
                 Brandenburg.put("end", 2);
                 Brandenburg.put("exceptionIf", 12);
                 exceptionsMicroData.put("out12", Brandenburg);
-            Map<String, Integer> MecklenburgVorpommern = new HashMap<>();
+            Map<String, Integer> MecklenburgVorpommern = new LinkedHashMap<>();
                 MecklenburgVorpommern.put("initial", 0);
                 MecklenburgVorpommern.put("end", 2);
                 MecklenburgVorpommern.put("exceptionIf", 13);
                 exceptionsMicroData.put("out13", MecklenburgVorpommern);
-            Map<String, Integer> Sachsen = new HashMap<>();
+            Map<String, Integer> Sachsen = new LinkedHashMap<>();
                 Sachsen.put("initial", 0);
                 Sachsen.put("end", 2);
                 Sachsen.put("exceptionIf", 14);
                 exceptionsMicroData.put("out14", Sachsen);
-            Map<String, Integer> SachsenAnhalt = new HashMap<>();
+            Map<String, Integer> SachsenAnhalt = new LinkedHashMap<>();
                 SachsenAnhalt.put("initial", 0);
                 SachsenAnhalt.put("end", 2);
                 SachsenAnhalt.put("exceptionIf", 15);
                 exceptionsMicroData.put("out15", SachsenAnhalt);
-            Map<String, Integer> Thueringen = new HashMap<>();
+            Map<String, Integer> Thueringen = new LinkedHashMap<>();
                 Thueringen.put("initial", 0);
                 Thueringen.put("end", 2);
                 Thueringen.put("exceptionIf", 16);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/manchester/preparation/ReadZonalData.java
@@ -21,6 +21,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ReadZonalData {
@@ -54,17 +55,17 @@ public class ReadZonalData {
         //List of municipalities and counties that are used for IPU and allocation
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         ArrayList<Integer> municipalitiesWithZero = new ArrayList<>();
 
-        HashMap<Integer, HashMap<String, Float>> attributesLSOA = new HashMap<>();
+        HashMap<Integer, HashMap<String, Float>> attributesLSOA = new LinkedHashMap<>();
 
         for (int row = 1; row <= PropertiesSynPop.get().main.selectedMunicipalities.getRowCount(); row++) {
             int city = (int) PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "lsoaID");
             float totalJobs = PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "tot");
             float percentageVacantDwellings = PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "percentageVacantDwellings");
 
-            HashMap<String, Float> attributes = new HashMap<>();
+            HashMap<String, Float> attributes = new LinkedHashMap<>();
             attributes.put("tot", totalJobs);
             attributes.put("percentageVacantDwellings", percentageVacantDwellings);
 
@@ -111,17 +112,17 @@ public class ReadZonalData {
 
     private void readZones(){
         //TAZ attributes
-        HashMap<Integer, int[]> cityTAZ = new HashMap<>();
-        Map<Integer, Map<Integer, Float>> probabilityZone = new HashMap<>();
-        Map<Integer, Map<ManchesterDwellingTypes.DwellingTypeManchester, Map<Integer, Float>>> probabilityZoneByDdType = new HashMap<>();
+        HashMap<Integer, int[]> cityTAZ = new LinkedHashMap<>();
+        Map<Integer, Map<Integer, Float>> probabilityZone = new LinkedHashMap<>();
+        Map<Integer, Map<ManchesterDwellingTypes.DwellingTypeManchester, Map<Integer, Float>>> probabilityZoneByDdType = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = HashBasedTable.create();
-        Map<Integer, Map<DwellingType, Integer>> dwellingPriceByTypeAndZone = new HashMap<>();
+        Map<Integer, Map<DwellingType, Integer>> dwellingPriceByTypeAndZone = new LinkedHashMap<>();
 
         ArrayList<Integer> tazs = new ArrayList<>();
         ArrayList<Float> areas = new ArrayList<>();
         TableDataSet zoneAttributes = PropertiesSynPop.get().main.cellsMatrix;
-        HashMap<Integer, HashMap<String, Float>> attributesZone = new HashMap<>();
-        HashMap<Integer, Integer> tazCity = new HashMap<>();
+        HashMap<Integer, HashMap<String, Float>> attributesZone = new LinkedHashMap<>();
+        HashMap<Integer, Integer> tazCity = new LinkedHashMap<>();
         for (int i = 1; i <= zoneAttributes.getRowCount(); i++){
             int city = (int) zoneAttributes.getValueAt(i,"lsoaID");
             int taz = (int) zoneAttributes.getValueAt(i,"oaID");
@@ -155,15 +156,15 @@ public class ReadZonalData {
             } else {
                 int[] previousTaz = {taz};
                 cityTAZ.put(city,previousTaz);
-                Map<Integer, Float> probabilities = new HashMap<>();
+                Map<Integer, Float> probabilities = new LinkedHashMap<>();
                 probabilities.put(taz, population);
                 probabilityZone.put(city, probabilities);
             }
 
             if(!probabilityZoneByDdType.containsKey(city)){
-                probabilityZoneByDdType.put(city, new HashMap<>() );
+                probabilityZoneByDdType.put(city, new LinkedHashMap<>() );
                 for(ManchesterDwellingTypes.DwellingTypeManchester ddType : ManchesterDwellingTypes.DwellingTypeManchester.values()){
-                    probabilityZoneByDdType.get(city).put(ddType, new HashMap<>());
+                    probabilityZoneByDdType.get(city).put(ddType, new LinkedHashMap<>());
                 }
             }
 
@@ -176,7 +177,7 @@ public class ReadZonalData {
             schoolCapacity.put(taz,2,capacitySecondarySchool);
             schoolCapacity.put(taz,3,capacityHigherEducation);
 
-            HashMap<String, Float> Attributes = new HashMap<>();
+            HashMap<String, Float> Attributes = new LinkedHashMap<>();
             Attributes.put("households", households);
             Attributes.put("tot",commuteInflow);
             Attributes.put("popCentroid_x",popCentroid_x);
@@ -218,7 +219,7 @@ public class ReadZonalData {
         //Read the commuteFlow
         logger.info("   Starting to read CSV matrix for car ownership");
         TableDataSet carOwnership = SiloUtil.readCSVfile(((ManchesterPropertiesSynPop)PropertiesSynPop.get().main).carOwnershipFile);
-        Map<Integer, Map<Integer, Map<Integer,Float>>> probability = new HashMap<>();
+        Map<Integer, Map<Integer, Map<Integer,Float>>> probability = new LinkedHashMap<>();
 
 
 
@@ -228,8 +229,8 @@ public class ReadZonalData {
             int car = (int) carOwnership.getValueAt(row, "carCode");
             float value = carOwnership.getValueAt(row, "Observation");
 
-            probability.computeIfAbsent(lsoaID, k -> new HashMap<>())
-                    .computeIfAbsent(hhsize, k -> new HashMap<>())
+            probability.computeIfAbsent(lsoaID, k -> new LinkedHashMap<>())
+                    .computeIfAbsent(hhsize, k -> new LinkedHashMap<>())
                     .put(car, value);
         }
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/CreateFreeFlowCarSkim.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/CreateFreeFlowCarSkim.java
@@ -62,7 +62,7 @@
 //        });
 //
 //
-//        final Map<Zone, Node> zoneCalculationNodesMap = new HashMap<>();
+//        final Map<Zone, Node> zoneCalculationNodesMap = new LinkedHashMap<>();
 //        for (Zone zone : zones) {
 //            Coordinate coordinate = zone.getRandomCoordinate();
 //            Coord originCoord = new Coord(coordinate.x, coordinate.y);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/SyntheticPopUs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/maryland/SyntheticPopUs.java
@@ -158,7 +158,7 @@ public class SyntheticPopUs implements SyntheticPopI {
     private void identifyUniquePUMAzones() {
         // walk through list of zones and collect unique PUMA zone IDs within the study area
 
-        tazByPuma = new HashMap<>();
+        tazByPuma = new LinkedHashMap<>();
         ArrayList<Integer> alHomePuma = new ArrayList<>();
         ArrayList<Integer> alWorkPuma = new ArrayList<>();
         for (Zone zone: geoData.getZones().values()) {
@@ -189,7 +189,7 @@ public class SyntheticPopUs implements SyntheticPopI {
 
         logger.info("  Reading control total data for households and dwellings");
 //        TableDataSet pop = SiloUtil.readCSVfile(Properties.get().main.baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_HOUSEHOLD_CONTROL_TOTAL));
-        householdTarget = new HashMap<>();
+        householdTarget = new LinkedHashMap<>();
 //        for (int row = 1; row <= pop.getRowCount(); row++) {
 //            String fips = String.valueOf(pop.getValueAt(row, "Fips"));
 //            // note: doesn't make much sense to store these data in a HashMap. It's legacy code.
@@ -211,7 +211,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // jobInventory by [industry][taz]
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         float[][] jobInventory = new float[JobType.getNumberOfJobTypes()][highestZoneId + 1];
-        tazByWorkZonePuma = new HashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
+        tazByWorkZonePuma = new LinkedHashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
 
         // read employment data
         // For reasons that are not explained in the documentation, some of the PUMA work zones were aggregated to the
@@ -255,7 +255,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // populate HashMap with Jobs by zone
 
         logger.info("  Identifying vacant jobs by zone");
-        vacantJobsByZone = new HashMap<>();
+        vacantJobsByZone = new LinkedHashMap<>();
         Collection<Job> jobs = jobData.getJobs();
         for (Job jj: jobs) {
             if (jj.getWorkerId() == -1) {
@@ -290,11 +290,11 @@ public class SyntheticPopUs implements SyntheticPopI {
 
         String[] states = {"md","dc","de","nj","pa","va","wv"};
 
-        jobErrorCounter = new HashMap<>();
+        jobErrorCounter = new LinkedHashMap<>();
 
         for (String state : states) {
-            Map<Integer, Integer> relationsHipsByPerson = new HashMap<>();
-            Map<Long, List<Household>> households = new HashMap<>();
+            Map<Integer, Integer> relationsHipsByPerson = new LinkedHashMap<>();
+            Map<Long, List<Household>> households = new LinkedHashMap<>();
 
             String pumsHhFileName = baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_PUMS_FILES) +
                     "ss16h" + state + ".csv";
@@ -778,7 +778,7 @@ public class SyntheticPopUs implements SyntheticPopI {
             return -2;  // person does work in puma zone outside of study area
         }
 
-        Map<Zone, Double> zoneProbabilities = new HashMap<>();
+        Map<Zone, Double> zoneProbabilities = new LinkedHashMap<>();
         for (Zone zone: geoData.getZones().values()) {
             if (vacantJobsByZone.containsKey(zone.getZoneId())) {
                 int numberOfJobsInThisZone = vacantJobsByZone.get(zone.getZoneId()).length;
@@ -943,7 +943,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // select number of cars for every household
         dataContainer.getJobDataManager().setup();
         MaryLandUpdateCarOwnershipModel ao = new MaryLandUpdateCarOwnershipModel(dataContainer, accessibility, Properties.get(), SiloUtil.provideNewRandom());   // calculate auto-ownership probabilities
-        Map<Integer, int[]> households = new HashMap<>();
+        Map<Integer, int[]> households = new LinkedHashMap<>();
         for (Household hh: householdData.getHouseholds()) {
             households.put(hh.getId(), null);
         }
@@ -956,7 +956,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         logger.info("  Adding empty dwellings to match vacancy rate");
 
         List<DwellingType> dwellingTypes = realEstateData.getDwellingTypes().getTypes();
-        HashMap<String, ArrayList<Integer>> ddPointer = new HashMap<>();
+        HashMap<String, ArrayList<Integer>> ddPointer = new LinkedHashMap<>();
         // summarize vacancy
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         int[][][] ddCount = new int [highestZoneId + 1][DefaultDwellingTypes.DefaultDwellingTypeImpl.values().length][2];

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/Allocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/Allocation.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class Allocation extends ModuleSynPop{
 
@@ -54,7 +55,7 @@ public class Allocation extends ModuleSynPop{
                 addBoroughsAsCities(county);
             }
         }
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new GenerateHouseholdsPersonsDwellings(dataContainer, dataSetSynPop, educationalLevel).run();
         if (PropertiesSynPop.get().main.boroughIPU){
             for (int county : dataSetSynPop.getBoroughsByCounty().keySet()){
@@ -76,7 +77,7 @@ public class Allocation extends ModuleSynPop{
     }
 
     public void readPopulation(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new ReadPopulation(dataContainer, educationalLevel).run();
     }
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignJobs.java
@@ -138,18 +138,18 @@ public class AssignJobs {
         Collection<Job> jobs = dataContainer.getJobDataManager().getJobs();
 
         jobStringTypes = PropertiesSynPop.get().main.jobStringType;
-        jobIntTypes = new HashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }
         tazIds = dataSetSynPop.getTazs().stream().mapToInt(i -> i).toArray();
 
-        idVacantJobsByZoneType = new HashMap<>();
-        numberVacantJobsByType = new HashMap<>();
-        idZonesVacantJobsByType = new HashMap<>();
-        numberZonesByType = new HashMap<>();
-        numberVacantJobsByZoneByType = new HashMap<>();
-        jobIntTypes = new HashMap<>();
+        idVacantJobsByZoneType = new LinkedHashMap<>();
+        numberVacantJobsByType = new LinkedHashMap<>();
+        idZonesVacantJobsByType = new LinkedHashMap<>();
+        numberZonesByType = new LinkedHashMap<>();
+        numberVacantJobsByZoneByType = new LinkedHashMap<>();
+        jobIntTypes = new LinkedHashMap<>();
         for (int i = 0; i < PropertiesSynPop.get().main.jobStringType.length; i++) {
             jobIntTypes.put(PropertiesSynPop.get().main.jobStringType[i], i);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignPropertiesToJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignPropertiesToJobs.java
@@ -96,10 +96,10 @@ public class AssignPropertiesToJobs {
     private void readCoefficients() {
         /*coefficients = PropertiesSynPop.get().main.fullTimeProbabilityTable;
         coefficients.buildStringIndex(1);*/
-        coefficientsFullTime = new HashMap<>();
-        coefficientsDuration = new HashMap<>();
-        coefficientsStartTimeWeekend = new HashMap<>();
-        coefficientsStartTimeWorkday = new HashMap<>();
+        coefficientsFullTime = new LinkedHashMap<>();
+        coefficientsDuration = new LinkedHashMap<>();
+        coefficientsStartTimeWeekend = new LinkedHashMap<>();
+        coefficientsStartTimeWorkday = new LinkedHashMap<>();
 
         for (String jobType : PropertiesSynPop.get().main.jobStringType) {
             Map<String, Double> coefficientsByJobType =

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignSchools.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/AssignSchools.java
@@ -96,7 +96,7 @@ public class AssignSchools {
 
         int schooltaz = -2;
         if (numberOfVacantPlacesByType.get(3) > 0) {
-            Map<Integer, Float> probability = new HashMap<>();
+            Map<Integer, Float> probability = new LinkedHashMap<>();
             Iterator<Integer> iterator = schoolCapacityMap.get(3).keySet().iterator();
             while (iterator.hasNext()) {
                 Integer zone = iterator.next();
@@ -160,8 +160,8 @@ public class AssignSchools {
 
     private void initializeSchoolCapacity(){
 
-        schoolCapacityMap = new HashMap<>();
-        numberOfVacantPlacesByType = new HashMap<>();
+        schoolCapacityMap = new LinkedHashMap<>();
+        numberOfVacantPlacesByType = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = dataSetSynPop.getSchoolCapacity();
         Iterator<Integer> iteratorRow = schoolCapacity.rowKeySet().iterator();
         while (iteratorRow.hasNext()){
@@ -171,7 +171,7 @@ public class AssignSchools {
                 int schoolType = iteratorCol.next();
                 int places = schoolCapacity.get(zone, schoolType);
                 if (places > 0) {
-                    Map<Integer, Integer> prevPlaces = new HashMap<>();
+                    Map<Integer, Integer> prevPlaces = new LinkedHashMap<>();
                     if (schoolCapacityMap.get(schoolType)!= null) {
                         prevPlaces = schoolCapacityMap.get(schoolType);
                     }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateHouseholdsPersonsDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateHouseholdsPersonsDwellings.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateHouseholdsPersonsDwellings {
@@ -174,7 +175,7 @@ public class GenerateHouseholdsPersonsDwellings {
         ddTypeProbOfSFAorSFD = PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality,"ddProbSFAorSFD");
         ddTypeProbOfMF234orMF5plus = PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality,"ddProbMF234orMF5plus");
         probTAZ = dataSetSynPop.getProbabilityZone().get(municipality);
-        probMicroData = new HashMap<>();
+        probMicroData = new LinkedHashMap<>();
         probabilityId = new double[dataSetSynPop.getWeights().getRowCount()];
         ids = new int[probabilityId.length];
         sumProbabilities = 0;

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateJobs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateJobs.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobs {
@@ -58,7 +59,7 @@ public class GenerateJobs {
 
 
     private void initializeTAZprobability(int municipality, String jobType){
-        jobsByTaz = new HashMap<>();
+        jobsByTaz = new LinkedHashMap<>();
         jobsByTaz.clear();
         for (int taz : dataSetSynPop.getTazByMunicipality().get(municipality)){
             jobsByTaz.put(taz, PropertiesSynPop.get().main.cellsMatrix.getIndexedValueAt(taz, jobType));

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateVacantDwellings.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/allocation/GenerateVacantDwellings.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateVacantDwellings {
@@ -92,11 +93,11 @@ public class GenerateVacantDwellings {
 
     private void initializeVacantDwellingData(int municipality){
 
-        probVacantFloor = new HashMap<>();
+        probVacantFloor = new LinkedHashMap<>();
         for (int floor : PropertiesSynPop.get().main.sizeBracketsDwelling) {
             probVacantFloor.put(floor, PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "vacantDwellings" + floor));
         }
-        probVacantBuildingSize = new HashMap<>();
+        probVacantBuildingSize = new LinkedHashMap<>();
         for (int year : PropertiesSynPop.get().main.yearBracketsDwelling){
             int sizeYear = year;
             String label = "vacantSmallDwellings" + year;
@@ -133,13 +134,13 @@ public class GenerateVacantDwellings {
                 }
                 ddQuality.put(key, qualities);
             } else {
-                Map<Integer, Float> qualities = new HashMap<>();
+                Map<Integer, Float> qualities = new LinkedHashMap<>();
                 qualities.put(quality, 1f);
                 ddQuality.put(key, qualities);
             }
         } else {
-            ddQuality = new HashMap<>();
-            Map<Integer, Float> qualities = new HashMap<>();
+            ddQuality = new LinkedHashMap<>();
+            Map<Integer, Float> qualities = new LinkedHashMap<>();
             qualities.put(quality, 1f);
             ddQuality.put(key, qualities);
         }
@@ -212,7 +213,7 @@ public class GenerateVacantDwellings {
     private int selectQualityVacant(int municipality, int year){
         int result = 0;
         if (ddQuality.get(year * 10000000 + municipality) == null) {
-            HashMap<Integer, Float> qualities = new HashMap<>();
+            HashMap<Integer, Float> qualities = new LinkedHashMap<>();
             for (int quality = 1; quality <= PropertiesSynPop.get().main.numberofQualityLevels; quality++){
                 qualities.put(quality, 1f);
             }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateDwellingMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateDwellingMicrolocation.java
@@ -12,6 +12,7 @@ import org.locationtech.jts.geom.Coordinate;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateDwellingMicrolocation {
@@ -20,13 +21,13 @@ public class GenerateDwellingMicrolocation {
     private static final double PENALTY = 0.5;
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private HashMap<Integer, Float> buildingX = new HashMap<>();
-    private HashMap<Integer, Float> buildingY = new HashMap<>();
-    private HashMap<Integer, HashMap<Integer,Double>> zoneBuildingMap = new HashMap<>();
-    Map<Integer, Integer> buildingZone = new HashMap<Integer, Integer>();
-    Map<Integer, Double> buildingArea = new HashMap<>();
-    Map<Integer, Float> zoneDensity = new HashMap<>();
-    Map<Integer, Integer> dwellingsInTAZ = new HashMap<Integer, Integer>();
+    private HashMap<Integer, Float> buildingX = new LinkedHashMap<>();
+    private HashMap<Integer, Float> buildingY = new LinkedHashMap<>();
+    private HashMap<Integer, HashMap<Integer,Double>> zoneBuildingMap = new LinkedHashMap<>();
+    Map<Integer, Integer> buildingZone = new LinkedHashMap<Integer, Integer>();
+    Map<Integer, Double> buildingArea = new LinkedHashMap<>();
+    Map<Integer, Float> zoneDensity = new LinkedHashMap<>();
+    Map<Integer, Integer> dwellingsInTAZ = new LinkedHashMap<Integer, Integer>();
 
     public GenerateDwellingMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataSetSynPop = dataSetSynPop;
@@ -79,7 +80,7 @@ public class GenerateDwellingMicrolocation {
             buildingZone.put(id,zone);
             //put all buildings with the same zoneID into one building list
             if (zoneBuildingMap.get(zone) == null){
-                HashMap<Integer, Double> buildingAreaList = new HashMap<Integer, Double>();
+                HashMap<Integer, Double> buildingAreaList = new LinkedHashMap<Integer, Double>();
                 zoneBuildingMap.put(zone,buildingAreaList);
             }
             zoneBuildingMap.get(zone).put(id,area);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateJobMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateJobMicrolocation.java
@@ -14,6 +14,7 @@ import org.locationtech.jts.geom.Coordinate;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobMicrolocation {
@@ -22,12 +23,12 @@ public class GenerateJobMicrolocation {
     
     private final DataContainer dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    private Map<Integer, Float> jobX = new HashMap<>();
-    private Map<Integer, Float> jobY = new HashMap<>();
-    Map<Integer, Integer> jobZone = new HashMap<Integer, Integer>();
-    Map<Integer, Map<String,Map<Integer,Float>>> zoneJobTypeJobLocationArea = new HashMap<>();
-    Map<Integer, Map<String,Float>> zoneJobTypeDensity = new HashMap<>();
-    Map<Integer, Map<String,Integer>> jobsByJobTypeInTAZ = new HashMap<>();
+    private Map<Integer, Float> jobX = new LinkedHashMap<>();
+    private Map<Integer, Float> jobY = new LinkedHashMap<>();
+    Map<Integer, Integer> jobZone = new LinkedHashMap<Integer, Integer>();
+    Map<Integer, Map<String,Map<Integer,Float>>> zoneJobTypeJobLocationArea = new LinkedHashMap<>();
+    Map<Integer, Map<String,Float>> zoneJobTypeDensity = new LinkedHashMap<>();
+    Map<Integer, Map<String,Integer>> jobsByJobTypeInTAZ = new LinkedHashMap<>();
     
     public GenerateJobMicrolocation(DataContainer dataContainer, DataSetSynPop dataSetSynPop){
         this.dataSetSynPop = dataSetSynPop;
@@ -69,9 +70,9 @@ public class GenerateJobMicrolocation {
     private void readJobFile() {
 
         for (int zone : dataSetSynPop.getTazs()){
-            Map<String,Map<Integer,Float>> jobLocationListForThisJobType = new HashMap<>();
+            Map<String,Map<Integer,Float>> jobLocationListForThisJobType = new LinkedHashMap<>();
             for (String jobType : PropertiesSynPop.get().main.jobStringType){
-                Map<Integer,Float> jobLocationAndArea = new HashMap<>();
+                Map<Integer,Float> jobLocationAndArea = new LinkedHashMap<>();
                 jobLocationListForThisJobType.put(jobType,jobLocationAndArea);
             }
             zoneJobTypeJobLocationArea.put(zone,jobLocationListForThisJobType);
@@ -121,8 +122,8 @@ public class GenerateJobMicrolocation {
 
     private void calculateDensity() {
         for (int zone : dataSetSynPop.getTazs()){
-            Map<String,Integer> jobsByJobType = new HashMap<>();
-            Map<String,Float> densityByJobType = new HashMap<>();
+            Map<String,Integer> jobsByJobType = new LinkedHashMap<>();
+            Map<String,Float> densityByJobType = new LinkedHashMap<>();
             jobsByJobTypeInTAZ.put(zone,jobsByJobType);
             zoneJobTypeDensity.put(zone,densityByJobType);
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateSchoolMicrolocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/GenerateSchoolMicrolocation.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateSchoolMicrolocation {
@@ -21,7 +22,7 @@ public class GenerateSchoolMicrolocation {
 
     private final DataContainerWithSchools dataContainer;
     private final DataSetSynPop dataSetSynPop;
-    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new HashMap<>();
+    Map<Integer, Map<Integer,Map<Integer,Integer>>> zoneSchoolTypeSchoolLocationCapacity = new LinkedHashMap<>();
 
 
     public GenerateSchoolMicrolocation(DataContainerWithSchools dataContainer, DataSetSynPop dataSetSynPop){
@@ -79,9 +80,9 @@ public class GenerateSchoolMicrolocation {
     private void createSchools() {
 
         for (int zone : dataSetSynPop.getTazs()){
-            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new HashMap<>();
+            Map<Integer,Map<Integer,Integer>> schoolLocationListForThisSchoolType = new LinkedHashMap<>();
             for (int type = 1 ; type <= 3; type++){
-                Map<Integer,Integer> schoolCapacity = new HashMap<>();
+                Map<Integer,Integer> schoolCapacity = new LinkedHashMap<>();
                 schoolLocationListForThisSchoolType.put(type,schoolCapacity);
             }
             zoneSchoolTypeSchoolLocationCapacity.put(zone,schoolLocationListForThisSchoolType);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/Microlocation.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/microlocation/Microlocation.java
@@ -12,6 +12,7 @@ import org.geotools.api.feature.simple.SimpleFeature;
 import org.matsim.core.utils.gis.ShapeFileReader;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Microlocation extends ModuleSynPop {
@@ -28,7 +29,7 @@ public class Microlocation extends ModuleSynPop {
         logger.info("   Started microlocation model.");
 
         String zoneShapeFile = Properties.get().geo.zoneShapeFile;
-        Map<Integer, SimpleFeature> zoneFeatureMap = new HashMap<>();
+        Map<Integer, SimpleFeature> zoneFeatureMap = new LinkedHashMap<>();
         for (SimpleFeature feature: ShapeFileReader.getAllFeatures(zoneShapeFile)) {
             int zoneId = Integer.parseInt(feature.getAttribute("id").toString());
             zoneFeatureMap.put(zoneId,feature);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/CheckHouseholdRelationship.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/CheckHouseholdRelationship.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CheckHouseholdRelationship {
@@ -312,10 +313,10 @@ public class CheckHouseholdRelationship {
         SiloUtil.addIntegerColumnToTableDataSet(microDataPerson, "rearrangedRole");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold,"nonClassifiedMales");
         SiloUtil.addIntegerColumnToTableDataSet(microDataHousehold, "nonClassifiedFemales"*//*);*/
-        childrenInHousehold = new HashMap<>();
-        noClass = new HashMap<>();
-        singles = new HashMap<>();
-        married = new HashMap<>();
+        childrenInHousehold = new LinkedHashMap<>();
+        noClass = new LinkedHashMap<>();
+        singles = new LinkedHashMap<>();
+        married = new LinkedHashMap<>();
     }
 
 
@@ -334,7 +335,7 @@ public class CheckHouseholdRelationship {
         }
         HashMap<Integer, Integer> inner = outer.get(key);
         if (inner == null){
-            inner = new HashMap<Integer, Integer>();
+            inner = new LinkedHashMap<Integer, Integer>();
             outer.put(key, inner);
         }
         inner.put(row, age);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/MicroDataManager.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/MicroDataManager.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MicroDataManager {
@@ -28,7 +29,7 @@ public class MicroDataManager {
 
     public HashMap<String, String[]> attributesMicroData(){
 
-        HashMap<String, String[]> attributesMicroData = new HashMap<>();
+        HashMap<String, String[]> attributesMicroData = new LinkedHashMap<>();
         String[] attributesPerson = {"age", "gender", "occupation", "income", "nationality", "telework", "ppPrivate", "educationDegree", "personStatus", "spouseInHousehold", "marriage", "relationship", "school"};
         String[] attributesHousehold = {"workers", "hhSize"};
         String[] attributesDwelling = {"ddUse", "ddYear", "ddFloor", "ddSize", "ddHeatingEnergy", "ddHeatingType", "ddAdHeating"};
@@ -41,62 +42,62 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesPersonMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> age = new HashMap<>();
+            Map<String, Integer> age = new LinkedHashMap<>();
                 age.put("initial", 50);
                 age.put("end", 52);
                 attributesIPU.put("age", age);
-            Map<String, Integer> gender = new HashMap<>();
+            Map<String, Integer> gender = new LinkedHashMap<>();
                 gender.put("initial", 54);
                 gender.put("end", 55);
                 attributesIPU.put("gender", gender);
-            Map<String, Integer> occupation = new HashMap<>();
+            Map<String, Integer> occupation = new LinkedHashMap<>();
                 occupation.put("initial", 32);
                 occupation.put("end", 33);
                 attributesIPU.put("occupation", occupation);
-            Map<String, Integer> nationality = new HashMap<>();
+            Map<String, Integer> nationality = new LinkedHashMap<>();
                 nationality.put("initial", 370);
                 nationality.put("end", 372);
                 attributesIPU.put("nationality", nationality);
         //Additional attributes
-            Map<String, Integer> income = new HashMap<>();
+            Map<String, Integer> income = new LinkedHashMap<>();
                 income.put("initial", 471);
                 income.put("end", 473);
                 attributesIPU.put("income", income);
-            Map<String, Integer> telework = new HashMap<>();
+            Map<String, Integer> telework = new LinkedHashMap<>();
                 telework.put("initial", 198);
                 telework.put("end", 200);
                 attributesIPU.put("telework", telework);
-            Map<String, Integer> ppPrivate = new HashMap<>();
+            Map<String, Integer> ppPrivate = new LinkedHashMap<>();
                 ppPrivate.put("initial", 34);
                 ppPrivate.put("end", 35);
                 attributesIPU.put("ppPrivate", ppPrivate);
-            Map<String, Integer> educationDegree = new HashMap<>();
+            Map<String, Integer> educationDegree = new LinkedHashMap<>();
                 educationDegree.put("initial", 323);
                 educationDegree.put("end", 325);
                 attributesIPU.put("educationDegree", educationDegree);
-            Map<String, Integer> status = new HashMap<>();
+            Map<String, Integer> status = new LinkedHashMap<>();
                 status.put("initial", 40);
                 status.put("end", 42);
                 attributesIPU.put("personStatus", status);
-            Map<String, Integer> spouse = new HashMap<>();
+            Map<String, Integer> spouse = new LinkedHashMap<>();
                 spouse.put("initial", 36);
                 spouse.put("end", 38);
                 attributesIPU.put("spouseInHousehold", spouse);
-            Map<String, Integer> marriage = new HashMap<>();
+            Map<String, Integer> marriage = new LinkedHashMap<>();
                 marriage.put("initial", 59);
                 marriage.put("end", 60);
                 attributesIPU.put("marriage", marriage);
-            Map<String, Integer> relationship = new HashMap<>();
+            Map<String, Integer> relationship = new LinkedHashMap<>();
                 relationship.put("initial", 566);
                 relationship.put("end", 568);
                 attributesIPU.put("relationship", relationship);
-            Map<String, Integer> school = new HashMap<>();
+            Map<String, Integer> school = new LinkedHashMap<>();
                 school.put("initial", 307);
                 school.put("end", 309);
                 attributesIPU.put("school", school);
-            Map<String, Integer> disability = new HashMap<>();
+            Map<String, Integer> disability = new LinkedHashMap<>();
                 disability.put("initial", 237);
                 disability.put("end", 239);
                 attributesIPU.put("disability", disability);
@@ -106,14 +107,14 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesHouseholdMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> hhSize = new HashMap<>();
+            Map<String, Integer> hhSize = new LinkedHashMap<>();
                 hhSize.put("initial", 26);
                 hhSize.put("end", 28);
                 attributesIPU.put("hhSize", hhSize);
         //Additional attributes
-            Map<String, Integer> workers = new HashMap<>();
+            Map<String, Integer> workers = new LinkedHashMap<>();
                 workers.put("initial", 572);
                 workers.put("end", 574);
                 attributesIPU.put("workers", workers);
@@ -123,34 +124,34 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> attributesDwellingMicroData(){
 
-        Map<String, Map<String, Integer>> attributesIPU = new HashMap<>();
+        Map<String, Map<String, Integer>> attributesIPU = new LinkedHashMap<>();
         //IPU attributes
-            Map<String, Integer> ddUse = new HashMap<>();
+            Map<String, Integer> ddUse = new LinkedHashMap<>();
                 ddUse.put("initial", 493);
                 ddUse.put("end", 495);
                 attributesIPU.put("ddUse", ddUse);
-            Map<String, Integer> ddYear = new HashMap<>();
+            Map<String, Integer> ddYear = new LinkedHashMap<>();
                 ddYear.put("initial", 500);
                 ddYear.put("end", 502);
                 attributesIPU.put("ddYear", ddYear);
-            Map<String, Integer> ddFloor = new HashMap<>();
+            Map<String, Integer> ddFloor = new LinkedHashMap<>();
                 ddFloor.put("initial", 495);
                 ddFloor.put("end", 498);
                 attributesIPU.put("ddFloor", ddFloor);
-            Map<String, Integer> ddSize = new HashMap<>();
+            Map<String, Integer> ddSize = new LinkedHashMap<>();
                 ddSize.put("initial", 491);
                 ddSize.put("end", 493);
                 attributesIPU.put("ddSize", ddSize);
         //Additional attributes
-            Map<String, Integer> ddHeatingEnergy = new HashMap<>();
+            Map<String, Integer> ddHeatingEnergy = new LinkedHashMap<>();
                 ddHeatingEnergy.put("initial", 506);
                 ddHeatingEnergy.put("end", 508);
                 attributesIPU.put("ddHeatingEnergy", ddHeatingEnergy);
-            Map<String, Integer> ddHeatingType = new HashMap<>();
+            Map<String, Integer> ddHeatingType = new LinkedHashMap<>();
                 ddHeatingType.put("initial", 504);
                 ddHeatingType.put("end", 506);
                 attributesIPU.put("ddHeatingType", ddHeatingType);
-            Map<String, Integer> ddAdHeating = new HashMap<>();
+            Map<String, Integer> ddAdHeating = new LinkedHashMap<>();
                 ddAdHeating.put("initial", 1017);
                 ddAdHeating.put("end", 1019);
                 attributesIPU.put("ddAdHeating", ddAdHeating);
@@ -159,108 +160,108 @@ public class MicroDataManager {
 
     public Map<String, Map<String, Integer>> exceptionsMicroData(){
 
-        Map<String, Map<String, Integer>> exceptionsMicroData = new HashMap<>();
-            Map<String, Integer> LivingInQuarter = new HashMap<>();
+        Map<String, Map<String, Integer>> exceptionsMicroData = new LinkedHashMap<>();
+            Map<String, Integer> LivingInQuarter = new LinkedHashMap<>();
                 LivingInQuarter.put("initial", 34);
                 LivingInQuarter.put("end", 35);
                 LivingInQuarter.put("exceptionIf", 2);
                 exceptionsMicroData.put("quarter", LivingInQuarter);
-            Map<String, Integer> noIncome = new HashMap<>();
+            Map<String, Integer> noIncome = new LinkedHashMap<>();
                 noIncome.put("initial", 658);
                 noIncome.put("end", 660);
                 noIncome.put("exceptionIf", 99);
                 exceptionsMicroData.put("noIncome", noIncome);
-            Map<String, Integer> movingOutInFiveYears = new HashMap<>();
+            Map<String, Integer> movingOutInFiveYears = new LinkedHashMap<>();
                 movingOutInFiveYears.put("initial", 491);
                 movingOutInFiveYears.put("end", 493);
                 movingOutInFiveYears.put("exceptionIf", -5);
                 exceptionsMicroData.put("movedOut", movingOutInFiveYears);
-            Map<String, Integer> noBuildingSize = new HashMap<>();
+            Map<String, Integer> noBuildingSize = new LinkedHashMap<>();
                 noBuildingSize.put("initial", 491);
                 noBuildingSize.put("end", 493);
                 noBuildingSize.put("exceptionIf", 9);
                 exceptionsMicroData.put("noSize", noBuildingSize);
-            Map<String, Integer> noDwellingUsage = new HashMap<>();
+            Map<String, Integer> noDwellingUsage = new LinkedHashMap<>();
                 noDwellingUsage.put("initial", 493);
                 noDwellingUsage.put("end", 495);
                 noDwellingUsage.put("exceptionIf", 9);
                 exceptionsMicroData.put("noUsage", noDwellingUsage);
-            Map<String, Integer> noBuildingYear = new HashMap<>();
+            Map<String, Integer> noBuildingYear = new LinkedHashMap<>();
                 noBuildingYear.put("initial", 500);
                 noBuildingYear.put("end", 502);
                 noBuildingYear.put("exceptionIf", 99);
                 exceptionsMicroData.put("noYear", noBuildingYear);
-            Map<String, Integer> SchleswigHolstein = new HashMap<>();
+            Map<String, Integer> SchleswigHolstein = new LinkedHashMap<>();
                 SchleswigHolstein.put("initial", 0);
                 SchleswigHolstein.put("end", 2);
                 SchleswigHolstein.put("exceptionIf", 1);
                 exceptionsMicroData.put("out1", SchleswigHolstein);
-            Map<String, Integer> Hamburg = new HashMap<>();
+            Map<String, Integer> Hamburg = new LinkedHashMap<>();
                 Hamburg.put("initial", 0);
                 Hamburg.put("end", 2);
                 Hamburg.put("exceptionIf", 2);
                 exceptionsMicroData.put("out2", Hamburg);
-            Map<String, Integer> Niedersachsen = new HashMap<>();
+            Map<String, Integer> Niedersachsen = new LinkedHashMap<>();
                 Niedersachsen.put("initial", 0);
                 Niedersachsen.put("end", 2);
                 Niedersachsen.put("exceptionIf", 3);
                 exceptionsMicroData.put("out3", Niedersachsen);
-            Map<String, Integer> Bremen = new HashMap<>();
+            Map<String, Integer> Bremen = new LinkedHashMap<>();
                 Bremen.put("initial", 0);
                 Bremen.put("end", 2);
                 Bremen.put("exceptionIf", 4);
                 exceptionsMicroData.put("out4", Bremen);
-            Map<String, Integer> NordrheinWestfalen = new HashMap<>();
+            Map<String, Integer> NordrheinWestfalen = new LinkedHashMap<>();
                 NordrheinWestfalen.put("initial", 0);
                 NordrheinWestfalen.put("end", 2);
                 NordrheinWestfalen.put("exceptionIf", 5);
                 exceptionsMicroData.put("out5", NordrheinWestfalen);
-            Map<String, Integer> Hessen = new HashMap<>();
+            Map<String, Integer> Hessen = new LinkedHashMap<>();
                 Hessen.put("initial", 0);
                 Hessen.put("end", 2);
                 Hessen.put("exceptionIf", 6);
                 exceptionsMicroData.put("out6", Hessen);
-            Map<String, Integer> RheinlandPfalz = new HashMap<>();
+            Map<String, Integer> RheinlandPfalz = new LinkedHashMap<>();
                 RheinlandPfalz.put("initial", 0);
                 RheinlandPfalz.put("end", 2);
                 RheinlandPfalz.put("exceptionIf", 7);
                 exceptionsMicroData.put("out7", RheinlandPfalz);
-            Map<String, Integer> BadenWuerttemberg = new HashMap<>();
+            Map<String, Integer> BadenWuerttemberg = new LinkedHashMap<>();
                 BadenWuerttemberg.put("initial", 0);
                 BadenWuerttemberg.put("end", 2);
                 BadenWuerttemberg.put("exceptionIf", 8);
                 exceptionsMicroData.put("out8", BadenWuerttemberg);
-            Map<String, Integer> Saarland = new HashMap<>();
+            Map<String, Integer> Saarland = new LinkedHashMap<>();
                 Saarland.put("initial", 0);
                 Saarland.put("end", 2);
                 Saarland.put("exceptionIf", 10);
                 exceptionsMicroData.put("out10", Saarland);
-            Map<String, Integer> Berlin = new HashMap<>();
+            Map<String, Integer> Berlin = new LinkedHashMap<>();
                 Berlin.put("initial", 0);
                 Berlin.put("end", 2);
                 Berlin.put("exceptionIf", 11);
                 exceptionsMicroData.put("out11", Berlin);
-            Map<String, Integer> Brandenburg = new HashMap<>();
+            Map<String, Integer> Brandenburg = new LinkedHashMap<>();
                 Brandenburg.put("initial", 0);
                 Brandenburg.put("end", 2);
                 Brandenburg.put("exceptionIf", 12);
                 exceptionsMicroData.put("out12", Brandenburg);
-            Map<String, Integer> MecklenburgVorpommern = new HashMap<>();
+            Map<String, Integer> MecklenburgVorpommern = new LinkedHashMap<>();
                 MecklenburgVorpommern.put("initial", 0);
                 MecklenburgVorpommern.put("end", 2);
                 MecklenburgVorpommern.put("exceptionIf", 13);
                 exceptionsMicroData.put("out13", MecklenburgVorpommern);
-            Map<String, Integer> Sachsen = new HashMap<>();
+            Map<String, Integer> Sachsen = new LinkedHashMap<>();
                 Sachsen.put("initial", 0);
                 Sachsen.put("end", 2);
                 Sachsen.put("exceptionIf", 14);
                 exceptionsMicroData.put("out14", Sachsen);
-            Map<String, Integer> SachsenAnhalt = new HashMap<>();
+            Map<String, Integer> SachsenAnhalt = new LinkedHashMap<>();
                 SachsenAnhalt.put("initial", 0);
                 SachsenAnhalt.put("end", 2);
                 SachsenAnhalt.put("exceptionIf", 15);
                 exceptionsMicroData.put("out15", SachsenAnhalt);
-            Map<String, Integer> Thueringen = new HashMap<>();
+            Map<String, Integer> Thueringen = new LinkedHashMap<>();
                 Thueringen.put("initial", 0);
                 Thueringen.put("end", 2);
                 Thueringen.put("exceptionIf", 16);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadMicroData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadMicroData.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ReadMicroData {
@@ -22,11 +23,11 @@ public class ReadMicroData {
 
     private final DataSetSynPop dataSetSynPop;
     private final MicroDataManager microDataManager;
-    private Map<String, Map<String, Integer>> exceptionsMicroData = new HashMap<>();
-    private HashMap<String, String[]> attributesMicroData = new HashMap<>();
-    private Map<String, Map<String, Integer>> attributesPersonMicroData = new HashMap<>();
-    private Map<String, Map<String, Integer>> attributesHouseholdMicroData = new HashMap<>();
-    private Map<String, Map<String, Integer>> attributesDwellingMicroData = new HashMap<>();
+    private Map<String, Map<String, Integer>> exceptionsMicroData = new LinkedHashMap<>();
+    private HashMap<String, String[]> attributesMicroData = new LinkedHashMap<>();
+    private Map<String, Map<String, Integer>> attributesPersonMicroData = new LinkedHashMap<>();
+    private Map<String, Map<String, Integer>> attributesHouseholdMicroData = new LinkedHashMap<>();
+    private Map<String, Map<String, Integer>> attributesDwellingMicroData = new LinkedHashMap<>();
     private Table<Integer, String, Integer> personTable = HashBasedTable.create();
     private Table<Integer, String, Integer> householdTable = HashBasedTable.create();
     private Table<Integer, String, Integer> dwellingTable = HashBasedTable.create();

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadZonalData.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/preparation/ReadZonalData.java
@@ -19,6 +19,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class ReadZonalData {
@@ -46,7 +47,7 @@ public class ReadZonalData {
         //List of municipalities and counties that are used for IPU and allocation
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         ArrayList<Integer> municipalitiesWithZero = new ArrayList<>();
         for (int row = 1; row <= PropertiesSynPop.get().main.selectedMunicipalities.getRowCount(); row++) {
             if (PropertiesSynPop.get().main.selectedMunicipalities.getValueAt(row, "Select") == 1f) {
@@ -77,7 +78,7 @@ public class ReadZonalData {
         dataSetSynPop.setMunicipalitiesWithZeroPopulation(municipalitiesWithZero);
 
         if (PropertiesSynPop.get().main.boroughIPU) {
-            HashMap<Integer, ArrayList> boroughsByCounty = new HashMap<>();
+            HashMap<Integer, ArrayList> boroughsByCounty = new LinkedHashMap<>();
             ArrayList<Integer> boroughs = new ArrayList<>();
             ArrayList<Integer> countieswithBoroughs = new ArrayList<>();
             for (int row = 1; row <= PropertiesSynPop.get().main.selectedBoroughs.getRowCount(); row++) {
@@ -105,9 +106,9 @@ public class ReadZonalData {
 
     private void readZones(){
         //TAZ attributes
-        HashMap<Integer, int[]> cityTAZ = new HashMap<>();
-        Map<Integer, Map<Integer, Float>> probabilityZone = new HashMap<>();
-        Map<Integer, Map<DwellingType, Integer>> dwellingPriceByTypeAndZone = new HashMap<>();
+        HashMap<Integer, int[]> cityTAZ = new LinkedHashMap<>();
+        Map<Integer, Map<Integer, Float>> probabilityZone = new LinkedHashMap<>();
+        Map<Integer, Map<DwellingType, Integer>> dwellingPriceByTypeAndZone = new LinkedHashMap<>();
         Table<Integer, Integer, Integer> schoolCapacity = HashBasedTable.create();
         ArrayList<Integer> tazs = new ArrayList<>();
         TableDataSet zoneAttributes;
@@ -139,11 +140,11 @@ public class ReadZonalData {
             } else {
                 int[] previousTaz = {taz};
                 cityTAZ.put(city,previousTaz);
-                Map<Integer, Float> probabilities = new HashMap<>();
+                Map<Integer, Float> probabilities = new LinkedHashMap<>();
                 probabilities.put(taz, probability);
                 probabilityZone.put(city, probabilities);
             }
-            Map<DwellingType, Integer> prices = new HashMap<>();
+            Map<DwellingType, Integer> prices = new LinkedHashMap<>();
             prices.put(DefaultDwellingTypes.DefaultDwellingTypeImpl.SFA, priceSFA);
             prices.put(DefaultDwellingTypes.DefaultDwellingTypeImpl.SFD, priceSFD);
             prices.put(DefaultDwellingTypes.DefaultDwellingTypeImpl.MF234, priceMF234);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/AllocationTrampa.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/AllocationTrampa.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class AllocationTrampa extends ModuleSynPop {
 
@@ -48,7 +49,7 @@ public class AllocationTrampa extends ModuleSynPop {
                 addBoroughsAsCities(county);
             }
         }
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new GenerateHouseholdsPersonsDwellingsTrampa(dataContainer, dataSetSynPop, educationalLevel).run();
         if (PropertiesSynPop.get().main.boroughIPU){
             for (int county : dataSetSynPop.getBoroughsByCounty().keySet()){
@@ -70,7 +71,7 @@ public class AllocationTrampa extends ModuleSynPop {
     }
 
     public void readPopulation(){
-        educationalLevel = new HashMap<>();
+        educationalLevel = new LinkedHashMap<>();
         new ReadPopulation(dataContainer, educationalLevel).run();
     }
 

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/GenerateHouseholdsPersonsDwellingsTrampa.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/GenerateHouseholdsPersonsDwellingsTrampa.java
@@ -16,10 +16,7 @@ import de.tum.bgu.msm.utils.SiloUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 public class GenerateHouseholdsPersonsDwellingsTrampa {
 
@@ -145,7 +142,7 @@ public class GenerateHouseholdsPersonsDwellingsTrampa {
 
         logger.info("   Municipality " + municipality + ". Starting to generate households and persons");
         totalHouseholds = (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, "hhTotal");
-        probMicroData = new HashMap<>();
+        probMicroData = new LinkedHashMap<>();
         probabilityId = new double[dataSetSynPop.getWeights().getRowCount()];
         ids = new int[probabilityId.length];
         for (int id : dataSetSynPop.getWeights().getColumnAsInt("ID")){

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/GenerateJobsTrampa.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/munich/synpopTrampa/GenerateJobsTrampa.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GenerateJobsTrampa {
@@ -62,7 +63,7 @@ public class GenerateJobsTrampa {
 
 
     private void initializeTAZprobability(int municipality, String jobType){
-        jobsByTaz = new HashMap<>();
+        jobsByTaz = new LinkedHashMap<>();
         for (int taz : dataSetSynPop.getTazByMunicipality().get(municipality)){
             jobsByTaz.put(taz, PropertiesSynPop.get().main.cellsMatrix.getIndexedValueAt(taz, jobType));
         }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCity.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCity.java
@@ -182,11 +182,11 @@ public class IPUbyCity {
         startTime = System.nanoTime();
 
         //weights, values, control totals
-        weightsByMun = Collections.synchronizedMap(new HashMap<>());
-        minWeightsByMun = Collections.synchronizedMap(new HashMap<>());
-        valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-        totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-        errorsByMunicipality = Collections.synchronizedMap(new HashMap<>());
+        weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        minWeightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorsByMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
 
         finish = 0;
         iteration = 0;
@@ -213,7 +213,7 @@ public class IPUbyCity {
                 errorsByMunicipality.put(attribute, 0.);
 
             } else {
-                HashMap<String, Integer> inner = new HashMap<>();
+                HashMap<String, Integer> inner = new LinkedHashMap<>();
                 inner.put(attribute, (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, attribute));
                 totalMunicipality.put(municipality, inner);
                 errorsByMunicipality.put(attribute, 0.);

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCountyAndCity.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCountyAndCity.java
@@ -7,10 +7,7 @@ import de.tum.bgu.msm.util.concurrent.ConcurrentExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.IntStream;
 
 public class IPUbyCountyAndCity {
@@ -130,7 +127,7 @@ public class IPUbyCountyAndCity {
         Iterator<Integer> iterator2 = dataSetSynPop.getMunicipalitiesByCounty().get(county).iterator();
         while (iterator2.hasNext()){
             Integer municipality = iterator2.next();
-            Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new HashMap<>());
+            Map<String, Double> errorsByMunicipality = Collections.synchronizedMap(new LinkedHashMap<>() );
             executor1.addTaskToQueue(() ->{
                 for (String attribute : PropertiesSynPop.get().main.attributesMunicipality){
                     double weightedSumMunicipality = SiloUtil.sumProduct(weightsByMun.get(municipality), valuesByHousehold.get(attribute));
@@ -244,13 +241,13 @@ public class IPUbyCountyAndCity {
         startTime = System.nanoTime();
 
         //weights, values, control totals
-        weightsByMun = Collections.synchronizedMap(new HashMap<>());
-        minWeightsByMun = Collections.synchronizedMap(new HashMap<>());
-        valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-        totalCounty = Collections.synchronizedMap(new HashMap<>());
-        totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-        errorByMun = Collections.synchronizedMap(new HashMap<>());
-        errorByRegion = Collections.synchronizedMap(new HashMap<>());
+        weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        minWeightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalCounty = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorByRegion = Collections.synchronizedMap(new LinkedHashMap<>());
 
         finish = 0;
         iteration = 0;
@@ -294,10 +291,10 @@ public class IPUbyCountyAndCity {
                     inner1.put(attribute, 0.);
                     errorByMun.put(municipality, inner1);
                 } else {
-                    HashMap<String, Integer> inner = new HashMap<>();
+                    HashMap<String, Integer> inner = new LinkedHashMap<>();
                     inner.put(attribute, (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, attribute));
                     totalMunicipality.put(municipality, inner);
-                    HashMap<String, Double> inner1 = new HashMap<>();
+                    HashMap<String, Double> inner1 = new LinkedHashMap<>();
                     inner1.put(attribute, 0.);
                     errorByMun.put(municipality, inner1);
                 }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCountyCityAndBorough.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/optimizationIPU/optimization/IPUbyCountyCityAndBorough.java
@@ -7,10 +7,7 @@ import de.tum.bgu.msm.util.concurrent.ConcurrentExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.IntStream;
 
 public class IPUbyCountyCityAndBorough {
@@ -174,7 +171,7 @@ public class IPUbyCountyCityAndBorough {
         Iterator<Integer> iterator2 = dataSetSynPop.getMunicipalitiesByCounty().get(county).iterator();
         while (iterator2.hasNext()) {
             Integer municipality = iterator2.next();
-            Map<String, Double> errorMunicipality = Collections.synchronizedMap(new HashMap<>());
+            Map<String, Double> errorMunicipality = Collections.synchronizedMap(new LinkedHashMap<>() );
             for (String attributeC : PropertiesSynPop.get().main.attributesMunicipality) {
                 double errorByCounty = 0.;
                 double weightedSumCounty = 0.;
@@ -202,7 +199,7 @@ public class IPUbyCountyCityAndBorough {
             Iterator<Integer> iterator1 = dataSetSynPop.getBoroughsByCounty().get(county).iterator();
             while (iterator1.hasNext()) {
                 Integer borough = iterator1.next();
-                Map<String, Double> errorsByBorough1 = Collections.synchronizedMap(new HashMap<>());
+                Map<String, Double> errorsByBorough1 = Collections.synchronizedMap(new LinkedHashMap<>());
                 executor1.addTaskToQueue(() -> {
                     for (String attribute : PropertiesSynPop.get().main.attributesBorough) {
                         double weightedSumMunicipality = SiloUtil.sumProduct(weightsByBorough.get(borough), valuesByHousehold.get(attribute));
@@ -331,15 +328,15 @@ public class IPUbyCountyCityAndBorough {
         startTime = System.nanoTime();
 
         //weights, values, control totals
-        weightsByBorough = Collections.synchronizedMap(new HashMap<>());
-        minWeightsByBorough = Collections.synchronizedMap(new HashMap<>());
-        valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-        totalCounty = Collections.synchronizedMap(new HashMap<>());
-        totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-        totalBorough = Collections.synchronizedMap(new HashMap<>());
-        errorByMun = Collections.synchronizedMap(new HashMap<>());
-        errorByRegion = Collections.synchronizedMap(new HashMap<>());
-        errorsByBorough = Collections.synchronizedMap(new HashMap<>());
+        weightsByBorough = Collections.synchronizedMap(new LinkedHashMap<>());
+        minWeightsByBorough = Collections.synchronizedMap(new LinkedHashMap<>());
+        valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalCounty = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+        totalBorough = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorByRegion = Collections.synchronizedMap(new LinkedHashMap<>());
+        errorsByBorough = Collections.synchronizedMap(new LinkedHashMap<>());
 
 
         finish = 0;
@@ -382,10 +379,10 @@ public class IPUbyCountyCityAndBorough {
                     inner1.put(attribute, 0.);
                     errorByMun.put(municipality, inner1);
                 } else {
-                    HashMap<String, Integer> inner = new HashMap<>();
+                    HashMap<String, Integer> inner = new LinkedHashMap<>();
                     inner.put(attribute, (int) PropertiesSynPop.get().main.marginalsMunicipality.getIndexedValueAt(municipality, attribute));
                     totalMunicipality.put(municipality, inner);
-                    HashMap<String, Double> inner1 = new HashMap<>();
+                    HashMap<String, Double> inner1 = new LinkedHashMap<>();
                     inner1.put(attribute, 0.);
                     errorByMun.put(municipality, inner1);
                 }
@@ -416,10 +413,10 @@ public class IPUbyCountyCityAndBorough {
                         inner1.put(attribute, 0.);
                         errorsByBorough.put(borough, inner1);
                     } else {
-                        HashMap<String, Integer> inner = new HashMap<>();
+                        HashMap<String, Integer> inner = new LinkedHashMap<>();
                         inner.put(attribute, (int) PropertiesSynPop.get().main.marginalsBorough.getIndexedValueAt(borough, attribute));
                         totalBorough.put(borough, inner);
-                        HashMap<String, Double> inner1 = new HashMap<>();
+                        HashMap<String, Double> inner1 = new LinkedHashMap<>();
                         inner1.put(attribute, 0.);
                         errorsByBorough.put(borough, inner1);
                     }

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/perth/SyntheticPopPerth.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/perth/SyntheticPopPerth.java
@@ -53,8 +53,8 @@ SyntheticPopPerth implements SyntheticPopI
     private TableDataSet genderPerArea = null;
     private TableDataSet dwellUnoccPerArea = null;
     private ArrayList<Dwelling> dwellingList = new ArrayList();
-    private HashMap<Integer, ZoneSA1[]> zoneMap = new HashMap<>();
-    private HashMap<Integer, ArrayList<Dwelling>> dwellingsPerZoneMap = new HashMap<>();
+    private HashMap<Integer, ZoneSA1[]> zoneMap = new LinkedHashMap<>();
+    private HashMap<Integer, ArrayList<Dwelling>> dwellingsPerZoneMap = new LinkedHashMap<>();
     private JobCollection jobCollection = new JobCollection();
     long unassignedWorker = 0;
     long unemployedCount = 0;
@@ -225,7 +225,7 @@ SyntheticPopPerth implements SyntheticPopI
         // for each row in the dwellings file
         for (int rowDd = 1; rowDd <= pumsDwellings.getRowCount(); rowDd++)
         {
-            HashMap<Integer, Family> familyMap = new HashMap<Integer, Family>();
+            HashMap<Integer, Family> familyMap = new LinkedHashMap<Integer, Family>();
 
             // get ABS dwelling id from the DWELLING file
             String dwellingId = pumsDwellings.getStringValueAt(rowDd, "ABSHID Dwelling Record Identifier");
@@ -429,7 +429,7 @@ SyntheticPopPerth implements SyntheticPopI
         and sums their relative price. This will be used to later
         calculate average for each zone and determine the quality.
      */
-    HashMap<Integer, DwellingQuality> qualityMap = new HashMap<Integer, DwellingQuality>();
+    HashMap<Integer, DwellingQuality> qualityMap = new LinkedHashMap<Integer, DwellingQuality>();
     private void addToQuality(int zone, int ddType, int price, int rooms)
     {
         DwellingQuality quality = qualityMap.get(zone);
@@ -1092,7 +1092,7 @@ SyntheticPopPerth implements SyntheticPopI
     private class JobCollection
     {
         ArrayList<JobSlot> jobSlots = new ArrayList<>();
-        HashMap<Integer, ArrayList<JobSlot>> jobTypesMap = new HashMap<>();
+        HashMap<Integer, ArrayList<JobSlot>> jobTypesMap = new LinkedHashMap<>();
 
         public JobCollection() { }
 
@@ -1233,7 +1233,7 @@ SyntheticPopPerth implements SyntheticPopI
 
         public int Zone = -1;
 
-        HashMap<Integer, DwellingQuality> TypeQuality = new HashMap<>();
+        HashMap<Integer, DwellingQuality> TypeQuality = new LinkedHashMap<>();
 
         public DwellingQuality() { }
 
@@ -1299,7 +1299,7 @@ SyntheticPopPerth implements SyntheticPopI
         // final int highestZoneId = 100;
         final int highestZoneId = 4953;
         float[][] jobInventory = new float[JobType.getNumberOfJobTypes()][highestZoneId + 1];
-        tazByWorkZonePuma = new HashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
+        tazByWorkZonePuma = new LinkedHashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
 
         // read employment data
         // For reasons that are not explained in the documentation, some of the PUMA work zones were aggregated to the
@@ -1353,7 +1353,7 @@ SyntheticPopPerth implements SyntheticPopI
         // populate HashMap with Jobs by zone
 
         logger.info("  Identifying vacant jobs by zone");
-        vacantJobsByZone = new HashMap<>();
+        vacantJobsByZone = new LinkedHashMap<>();
         Collection<Job> jobs = jobData.getJobs();
         for (Job jj: jobs) {
             if (jj.getWorkerId() == -1) {
@@ -1603,7 +1603,7 @@ SyntheticPopPerth implements SyntheticPopI
 
         logger.info("  Adding empty dwellings to match vacancy rate");
 
-        HashMap<String, ArrayList<Integer>> ddPointer = new HashMap<>();
+        HashMap<String, ArrayList<Integer>> ddPointer = new LinkedHashMap<>();
         // summarize vacancy
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         int[][][] ddCount = new int [highestZoneId + 1][DwellingType.values().length][2];

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/sanFrancisco/CreateSkimFromUber.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/sanFrancisco/CreateSkimFromUber.java
@@ -13,10 +13,7 @@ import org.matsim.core.utils.gis.ShapeFileReader;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class CreateSkimFromUber {
@@ -30,7 +27,7 @@ public class CreateSkimFromUber {
 
         final Collection<SimpleFeature> features = ShapeFileReader.getAllFeatures("Z:\\projects\\2019\\TraMPA" +
                 "\\San Francisco\\Data\\TAZ\\censusTractsNineCountiesTaz\\censusTracts_projected_7131_uberId.shp");
-        final Map<Integer, Integer> movementId2zoneId = new HashMap<>();
+        final Map<Integer, Integer> movementId2zoneId = new LinkedHashMap<>();
         features.forEach(simpleFeature -> {
             final int tractce = Integer.parseInt(String.valueOf(simpleFeature.getAttribute("TRACTCE")));
             final int uberId = Integer.parseInt(String.valueOf(simpleFeature.getAttribute("MOVEMENT_I")));

--- a/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/sanFrancisco/SyntheticPopUs.java
+++ b/synthetic-population/src/main/java/de/tum/bgu/msm/syntheticPopulationGenerator/sanFrancisco/SyntheticPopUs.java
@@ -160,8 +160,8 @@ public class SyntheticPopUs implements SyntheticPopI {
 
     private void identifyCensusBlockGroups() {
 
-        censusBlockGroupsByCensusTracts = new HashMap<>();
-        geometryByCensusBlockGroup = new HashMap<>();
+        censusBlockGroupsByCensusTracts = new LinkedHashMap<>();
+        geometryByCensusBlockGroup = new LinkedHashMap<>();
 
         String filePath =Properties.get().main.baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_BLOCK_GROUPS_PATH);
         for (SimpleFeature feature : ShapeFileReader.getAllFeatures(filePath)) {
@@ -180,7 +180,7 @@ public class SyntheticPopUs implements SyntheticPopI {
     private void identifyUniquePUMAzones() {
         // walk through list of zones and collect unique PUMA zone IDs within the study area
 
-        tazByPuma = new HashMap<>();
+        tazByPuma = new LinkedHashMap<>();
         Set<Integer> alHomePuma = new HashSet<>();
         Set<Integer> alWorkPuma = new HashSet<>();
         for (Zone zone : geoData.getZones().values()) {
@@ -223,7 +223,7 @@ public class SyntheticPopUs implements SyntheticPopI {
         // jobInventory by [industry][taz]
         final int highestZoneId = geoData.getZones().keySet().stream().max(Comparator.naturalOrder()).get();
         float[][] jobInventory = new float[JobType.getNumberOfJobTypes()][highestZoneId + 1];
-        tazByWorkZonePuma = new HashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
+        tazByWorkZonePuma = new LinkedHashMap<>();  // this HashMap has same content as "HashMap tazByPuma", though is kept separately in case external workzones will be defined
 
         // read employment data
         // For reasons that are not explained in the documentation, some of the PUMA work zones were aggregated to the
@@ -266,7 +266,7 @@ public class SyntheticPopUs implements SyntheticPopI {
     private void identifyVacantJobsByZone() {
         // populate HashMap with Jobs by zone
         logger.info("  Identifying vacant jobs by zone");
-        vacantJobsByZone = new HashMap<>();
+        vacantJobsByZone = new LinkedHashMap<>();
         Collection<Job> jobs = jobData.getJobs();
         for (Job jj : jobs) {
             if (jj.getWorkerId() == -1) {
@@ -283,10 +283,10 @@ public class SyntheticPopUs implements SyntheticPopI {
     private void processPums() {
         // read PUMS data
         logger.info("  Reading PUMS data");
-        jobErrorCounter = new HashMap<>();
+        jobErrorCounter = new LinkedHashMap<>();
 
-            Map<Integer, Integer> relationsHipsByPerson = new HashMap<>();
-            Map<String, List<Household>> households = new HashMap<>();
+            Map<Integer, Integer> relationsHipsByPerson = new LinkedHashMap<>();
+            Map<String, List<Household>> households = new LinkedHashMap<>();
 
             logger.info("  Creating synthetic population");
             String hhFilePath =Properties.get().main.baseDirectory + ResourceUtil.getProperty(rb, PROPERTIES_PUMS_HH_FILE_NAME);
@@ -841,7 +841,7 @@ public class SyntheticPopUs implements SyntheticPopI {
             return null;  // person does work in puma zone outside of study area
         }
 
-        Map<Zone, Double> zoneProbabilities = new HashMap<>();
+        Map<Zone, Double> zoneProbabilities = new LinkedHashMap<>();
         Zone homeZone = geoData.getZones().get(homeTaz);
         for (Zone zone : geoData.getZones().values()) {
             if (vacantJobsByZone.containsKey(zone.getZoneId())) {

--- a/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTest.java
+++ b/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTest.java
@@ -11,6 +11,8 @@ import javax.script.ScriptException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,7 +49,7 @@ public class ipuTest {
         System.arraycopy(attributesCounty1, 1, attributesCounty, 0, attributesCounty.length);
         ArrayList<Integer> municipalities = new ArrayList<>();
         ArrayList<Integer> counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         for (int row = 1; row <= selectedMunicipalities.getRowCount(); row++){
             if (selectedMunicipalities.getValueAt(row,"Select") == 1f){
                 int city = (int) selectedMunicipalities.getValueAt(row,"ID_city");

--- a/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTestOpt.java
+++ b/synthetic-population/src/test/java/de/tum/bgu/msm/syntheticPopulation/ipuTestOpt.java
@@ -51,7 +51,7 @@ public class ipuTestOpt {
         for (int i = 0; i < attributesCounty.length; i++){attributesCounty[i] = attributesCounty1[i+1];}
         municipalities = new ArrayList<>();
         counties = new ArrayList<>();
-        municipalitiesByCounty = new HashMap<>();
+        municipalitiesByCounty = new LinkedHashMap<>();
         for (int row = 1; row <= selectedMunicipalities.getRowCount(); row++){
             if (selectedMunicipalities.getValueAt(row,"Select") == 1f){
                 int city = (int) selectedMunicipalities.getValueAt(row,"ID_city");
@@ -99,13 +99,13 @@ public class ipuTestOpt {
         //int position = 0;
 
         //weights, values, control totals
-        Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new HashMap<>());
-        Map<Integer, double[]> minWeightsByMun =Collections.synchronizedMap(new HashMap<>());
-        Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new HashMap<>());
-        Map<String, Integer> totalCounty = Collections.synchronizedMap(new HashMap<>());
-        Map<Integer, HashMap<String, Integer>> totalMunicipality = Collections.synchronizedMap(new HashMap<>());
-        Map<Integer, HashMap<String, Double>> errorByMun = Collections.synchronizedMap(new HashMap<>());
-        Map<String, Double> errorByRegion = Collections.synchronizedMap(new HashMap<>());
+        Map<Integer, double[]> weightsByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<Integer, double[]> minWeightsByMun =Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<String, int[]> valuesByHousehold = Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<String, Integer> totalCounty = Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<Integer, HashMap<String, Integer>> totalMunicipality = Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<Integer, HashMap<String, Double>> errorByMun = Collections.synchronizedMap(new LinkedHashMap<>());
+        Map<String, Double> errorByRegion = Collections.synchronizedMap(new LinkedHashMap<>());
         double weightedSum0 = 0f;
 
         int finish = 0;
@@ -156,10 +156,10 @@ public class ipuTestOpt {
                         inner1.put(attribute, 0.);
                         errorByMun.put(municipality, inner1);
                     } else {
-                        HashMap<String, Integer> inner = new HashMap<>();
+                        HashMap<String, Integer> inner = new LinkedHashMap<>();
                         inner.put(attribute, (int) controlTotalsMun.getIndexedValueAt(municipality, attribute));
                         totalMunicipality.put(municipality, inner);
-                        HashMap<String, Double> inner1 = new HashMap<>();
+                        HashMap<String, Double> inner1 = new LinkedHashMap<>();
                         inner1.put(attribute, 0.);
                         errorByMun.put(municipality, inner1);
                     }
@@ -233,7 +233,7 @@ public class ipuTestOpt {
                         }
                         HashMap<String, Double> inner = errorByMun.get(municipality);
                         if (inner == null) {
-                            inner = new HashMap<String, Double>();
+                            inner = new LinkedHashMap<String, Double>();
                             errorByMun.put(municipality, inner);
                         }
                         inner.put(attribute, error);

--- a/useCases/bangkok/src/main/java/de/tum/bgu/msm/run/data/jobs/BangkokJobFactory.java
+++ b/useCases/bangkok/src/main/java/de/tum/bgu/msm/run/data/jobs/BangkokJobFactory.java
@@ -12,6 +12,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -47,7 +48,7 @@ public class BangkokJobFactory implements JobFactory {
                     if (startTimeDistributionByJobType.containsKey(header[column])) {
                         startTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> startTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> startTimeDistribution = new LinkedHashMap<>();
                         startTimeDistribution.put(time, Double.parseDouble(row[column]));
                         startTimeDistributionByJobType.put(header[column], startTimeDistribution);
                     }
@@ -70,7 +71,7 @@ public class BangkokJobFactory implements JobFactory {
                     if (workingTimeDistributionByJobType.containsKey(header[column])) {
                         workingTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> workingTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> workingTimeDistribution = new LinkedHashMap<>();
                         workingTimeDistribution.put(time, Double.parseDouble(row[column]));
                         workingTimeDistributionByJobType.put(header[column], workingTimeDistribution);
                     }

--- a/useCases/berlinBrandenburg/src/main/java/de/tum/bgu/msm/data/job/JobFactoryBerlinBrandenburg.java
+++ b/useCases/berlinBrandenburg/src/main/java/de/tum/bgu/msm/data/job/JobFactoryBerlinBrandenburg.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -43,7 +44,7 @@ public class JobFactoryBerlinBrandenburg implements JobFactory {
                     if (startTimeDistributionByJobType.containsKey(header[column])) {
                         startTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> startTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> startTimeDistribution = new LinkedHashMap<>();
                         startTimeDistribution.put(time, Double.parseDouble(row[column]));
                         startTimeDistributionByJobType.put(header[column], startTimeDistribution);
                     }
@@ -66,7 +67,7 @@ public class JobFactoryBerlinBrandenburg implements JobFactory {
                     if (workingTimeDistributionByJobType.containsKey(header[column])) {
                         workingTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> workingTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> workingTimeDistribution = new LinkedHashMap<>();
                         workingTimeDistribution.put(time, Double.parseDouble(row[column]));
                         workingTimeDistributionByJobType.put(header[column], workingTimeDistribution);
                     }

--- a/useCases/berlinBrandenburg/src/main/java/de/tum/bgu/msm/models/carOwnership/SwitchToAutonomousVehicleModelBerlinBrandenburg.java
+++ b/useCases/berlinBrandenburg/src/main/java/de/tum/bgu/msm/models/carOwnership/SwitchToAutonomousVehicleModelBerlinBrandenburg.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ public class SwitchToAutonomousVehicleModelBerlinBrandenburg extends AbstractMod
     /**
      * this variable stores a summary for print out purposes
      */
-    private Map<String, Integer> summary = new HashMap<>();
+    private Map<String, Integer> summary = new LinkedHashMap<>();
 
     public SwitchToAutonomousVehicleModelBerlinBrandenburg(DataContainer dataContainer, Properties properties, InputStream inputStream, Random rnd) {
         super(dataContainer, properties, rnd);

--- a/useCases/capeTown/src/main/java/de/tum/bgu/msm/models/relocation/HousingStrategyCapeTown.java
+++ b/useCases/capeTown/src/main/java/de/tum/bgu/msm/models/relocation/HousingStrategyCapeTown.java
@@ -26,10 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
 
@@ -70,8 +67,8 @@ public class HousingStrategyCapeTown implements HousingStrategy {
     private final RegionUtilityStrategy regionUtilityStrategy;
     private final RegionProbabilityStrategy regionProbabilityStrategy;
 
-    private Map<Integer, Map<RaceCapeTown, Double>> personShareByRaceByRegion = new HashMap<>();
-    private Map<Integer, Map<RaceCapeTown, Double>> personShareByRaceByZone = new HashMap<>();
+    private Map<Integer, Map<RaceCapeTown, Double>> personShareByRaceByRegion = new LinkedHashMap<>();
+    private Map<Integer, Map<RaceCapeTown, Double>> personShareByRaceByZone = new LinkedHashMap<>();
 
     private IndexedDoubleMatrix1D ppByRegion;
     private IndexedDoubleMatrix1D ppByZone;
@@ -218,7 +215,7 @@ public class HousingStrategyCapeTown implements HousingStrategy {
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
             EnumMap<RaceCapeTown, Map<Integer, Double>> utilityByRegionByRace = new EnumMap<>(RaceCapeTown.class);
             for (RaceCapeTown race : RaceCapeTown.values()) {
-                Map<Integer, Double> utilityByRegion = new HashMap<>();
+                Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
                 for (Region region : geoData.getRegions().values()) {
                     if (!rentsByRegion.containsKey(region.getId())) {
                         continue;

--- a/useCases/fabiland/src/main/java/inputGeneration/CreateShapefile.java
+++ b/useCases/fabiland/src/main/java/inputGeneration/CreateShapefile.java
@@ -20,7 +20,7 @@ public class CreateShapefile {
 
         GeometryFactory geometryFactory = new GeometryFactory();
 
-        Map<Integer, Polygon> polygons = new HashMap<>();
+        Map<Integer, Polygon> polygons = new LinkedHashMap<>();
 
         int sideLengthHorizonal = 5000;
         int sideLengthVertical = 5000;

--- a/useCases/fabiland/src/main/java/inputGeneration/PTScheduleCreator.java
+++ b/useCases/fabiland/src/main/java/inputGeneration/PTScheduleCreator.java
@@ -379,7 +379,7 @@ public class PTScheduleCreator {
     }
 
 //    static void setLinkSpeedsToMax(Scenario scenario) {
-//        Map<Id<Link>, Double> linkMaxSpeed = new HashMap<>();
+//        Map<Id<Link>, Double> linkMaxSpeed = new LinkedHashMap<>();
 //
 //        for (Link link : scenario.getNetwork().getLinks().values()) {
 //            linkMaxSpeed.put(link.getId(), 0.);

--- a/useCases/fabiland/src/test/java/run/RunFabilandTest.java
+++ b/useCases/fabiland/src/test/java/run/RunFabilandTest.java
@@ -83,6 +83,8 @@ public class RunFabilandTest{
 				PopulationComparison.Result result = PopulationUtils.comparePopulations( expected, actual );
 //				Assertions.assertEquals( PopulationComparison.Result.equal, result );
 			}
+			log.info("############################################");
+			log.info("############################################");
 			{
 				String expected = inputDirectory + "/1.output_events.xml.gz" ;
 				String actual = "scenario/scenOutput/base/matsim/1/1.output_events.xml.gz" ;

--- a/useCases/fabiland/src/test/java/run/RunFabilandTest.java
+++ b/useCases/fabiland/src/test/java/run/RunFabilandTest.java
@@ -71,7 +71,7 @@ public class RunFabilandTest{
 				String expected = inputDirectory + "/1.0.events.xml.gz" ;
 				String actual = "scenario/scenOutput/base/matsim/1/ITERS/it.0/1.0.events.xml.gz" ;
 				ComparisonResult result = EventsUtils.compareEventsFiles( expected, actual );
-//				Assertions.assertEquals( FILES_ARE_EQUAL, result );
+				Assertions.assertEquals( FILES_ARE_EQUAL, result );
 			}
 
 			log.info("############################################");
@@ -81,7 +81,7 @@ public class RunFabilandTest{
 				final String expected = inputDirectory + "1.output_plans.xml.gz";
 				final String actual = "scenario/scenOutput/base/matsim/1/1.output_plans.xml.gz";
 				PopulationComparison.Result result = PopulationUtils.comparePopulations( expected, actual );
-//				Assertions.assertEquals( PopulationComparison.Result.equal, result );
+				Assertions.assertEquals( PopulationComparison.Result.equal, result );
 			}
 			log.info("############################################");
 			log.info("############################################");
@@ -89,7 +89,7 @@ public class RunFabilandTest{
 				String expected = inputDirectory + "/1.output_events.xml.gz" ;
 				String actual = "scenario/scenOutput/base/matsim/1/1.output_events.xml.gz" ;
 				ComparisonResult result = EventsUtils.compareEventsFiles( expected, actual );
-//				Assertions.assertEquals( FILES_ARE_EQUAL, result );
+				Assertions.assertEquals( FILES_ARE_EQUAL, result );
 			}
 
 			log.info("############################################");

--- a/useCases/fabiland/src/test/java/run/RunFabilandTest.java
+++ b/useCases/fabiland/src/test/java/run/RunFabilandTest.java
@@ -63,7 +63,7 @@ public class RunFabilandTest{
 				final String expected = inputDirectory + "1.0.plans.xml.gz";
 				final String actual = "scenario/scenOutput/base/matsim/1/ITERS/it.0/1.0.plans.xml.gz";
 				PopulationComparison.Result result = PopulationUtils.comparePopulations( expected, actual );
-//				Assertions.assertEquals( PopulationComparison.Result.equal, result );
+				Assertions.assertEquals( PopulationComparison.Result.equal, result );
 			}
 			log.info("############################################");
 			log.info("############################################");

--- a/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/coreCityDevelopment/CoreCityJobMarketUpdateTak.java
+++ b/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/coreCityDevelopment/CoreCityJobMarketUpdateTak.java
@@ -59,7 +59,7 @@ public class CoreCityJobMarketUpdateTak extends AbstractModel implements JobMark
             jobsByZone[jobTypeId][jj.getZoneId()]++;
         }
 
-        Map<String, List<Integer>> jobsAvailableForRemoval = new HashMap<>();
+        Map<String, List<Integer>> jobsAvailableForRemoval = new LinkedHashMap<>();
         for (Job jj : jobDataManager.getJobs()) {
             String token = jj.getType() + "." + jj.getZoneId() + "." + (jj.getWorkerId() == -1);
             if (jobsAvailableForRemoval.containsKey(token)) {

--- a/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/draconicResettlement/DraconicResettlementJobMarketUpdateTak.java
+++ b/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/draconicResettlement/DraconicResettlementJobMarketUpdateTak.java
@@ -66,7 +66,7 @@ public class DraconicResettlementJobMarketUpdateTak extends AbstractModel implem
         logger.info("  Updating job market based on exogenous forecast for " + year + " (multi-threaded step)");
 
 
-        Map<String, List<Integer>> jobsAvailableForRemoval = new HashMap<>();
+        Map<String, List<Integer>> jobsAvailableForRemoval = new LinkedHashMap<>();
         for (Job jj : jobDataManager.getJobs()) {
             String token = jj.getType() + "." + jj.getZoneId() + "." + (jj.getWorkerId() == -1);
             if (jobsAvailableForRemoval.containsKey(token)) {

--- a/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/longCommutePenalty/LongCommutePenaltytHousingStrategyTak.java
+++ b/useCases/kagawa/src/main/java/de/tum/bgu/msm/scenarios/longCommutePenalty/LongCommutePenaltytHousingStrategyTak.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.TransportMode;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static de.tum.bgu.msm.data.dwelling.RealEstateUtils.RENT_CATEGORIES;
@@ -255,7 +256,7 @@ public class LongCommutePenaltytHousingStrategyTak implements HousingStrategy {
         final Map<Integer, Double> rentsByRegion = dataContainer.getRealEstateDataManager().calculateRegionalPrices();
         thisYearRentByRegion = rentsByRegion;
         for (IncomeCategory incomeCategory : IncomeCategory.values()) {
-            Map<Integer, Double> utilityByRegion = new HashMap<>();
+            Map<Integer, Double> utilityByRegion = new LinkedHashMap<>();
             for (Region region : geoData.getRegions().values()) {
                 final int averageRegionalRent = rentsByRegion.get(region.getId()).intValue();
                 final float regAcc = (float) convertAccessToUtility(accessibility.getRegionalAccessibility(region));

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DataBuilderHealth.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DataBuilderHealth.java
@@ -31,6 +31,7 @@ import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class DataBuilderHealth {
@@ -126,7 +127,7 @@ public class DataBuilderHealth {
         new PoiReader(dataContainer).readData(properties.main.baseDirectory + properties.geo.poiFileName);
 
         Network network = NetworkUtils.readNetwork(config.network().getInputFile());
-        Map<Id<Link>, LinkInfo> linkInfoMap = new HashMap<>();
+        Map<Id<Link>, LinkInfo> linkInfoMap = new LinkedHashMap<>();
         for(Link link : network.getLinks().values()){
             linkInfoMap.put(link.getId(), new LinkInfo(link.getId()));
         }

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthDataContainerImpl.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthDataContainerImpl.java
@@ -33,13 +33,13 @@ public class HealthDataContainerImpl implements DataContainerWithSchools, DataCo
 
     private final DataContainerWithSchools delegate;
     private final Properties properties;
-    private Map<Id<Link>, LinkInfo> linkInfo = new HashMap<>();
-    private Map<String, ActivityLocation> activityLocationInfo = new HashMap<>();
+    private Map<Id<Link>, LinkInfo> linkInfo = new LinkedHashMap<>();
+    private Map<String, ActivityLocation> activityLocationInfo = new LinkedHashMap<>();
     private Set<Pollutant> pollutantSet = new HashSet<>();
     private EnumMap<Mode, EnumMap<MitoGender,Map<Integer,Double>>> avgSpeeds;
     private EnumMap<Diseases, Map<String, Double>> healthTransitionData;
     private EnumMap<HealthExposures, EnumMap<Diseases, TableDataSet>> doseResponseData;
-    private Map<Integer, Map<Integer, List<String>>> healthDiseaseTrackerRemovedPerson = new HashMap<>();
+    private Map<Integer, Map<Integer, List<String>>> healthDiseaseTrackerRemovedPerson = new LinkedHashMap<>();
 
     public HealthDataContainerImpl(DataContainerWithSchools delegate,
                                    Properties properties) {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMCR.java
@@ -70,7 +70,7 @@ public class HealthExposureModelMCR extends AbstractModel implements ModelUpdate
     private int latestMatsimYear = -1;
     private int latestMITOYear = -1;
     private static final Logger logger = LogManager.getLogger(HealthExposureModelMCR.class);
-    private Map<Integer, Trip> mitoTrips = new HashMap<>();
+    private Map<Integer, Trip> mitoTrips = new LinkedHashMap<>();
     private final Config initialMatsimConfig;
     private MutableScenario scenario;
     private List<Day> simulatedDays;

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/MatsimTransportModelMCRHealth.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/MatsimTransportModelMCRHealth.java
@@ -246,7 +246,7 @@ public final class MatsimTransportModelMCRHealth implements TransportModel {
                 Id<Vehicle> vehicleId = Id.createVehicleId(person.getId().toString());
                 VehicleType vehicleType = matsimScenario.getVehicles().getVehicleTypes().get(Id.create(mode + gender + age, VehicleType.class));
                 Vehicle veh = fac.createVehicle(vehicleId,vehicleType);
-                Map<String,Id<Vehicle>> modeToVehicle = new HashMap<>();
+                Map<String,Id<Vehicle>> modeToVehicle = new LinkedHashMap<>();
                 modeToVehicle.put(mode,vehicleId);
                 VehicleUtils.insertVehicleIdsIntoPersonAttributes(person,modeToVehicle);
                 matsimScenario.getVehicles().addVehicle(veh);

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/MitoMatsimScenarioAssemblerMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/MitoMatsimScenarioAssemblerMCR.java
@@ -26,6 +26,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 import uk.cam.mrc.phm.MitoModelMCR;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -72,9 +73,9 @@ public class MitoMatsimScenarioAssemblerMCR implements MatsimScenarioAssembler {
         mito.run();
 
         logger.info("  Receiving demand from MITO");
-        Map<Day, Scenario> scenarios = new HashMap<>();
+        Map<Day, Scenario> scenarios = new LinkedHashMap<>();
 
-        Map<Day, Population> populationByDay = new HashMap();
+        Map<Day, Population> populationByDay = new LinkedHashMap();
 
         for(Person person: dataSet.getPopulation().getPersons().values()){
             Day day = Day.valueOf((String)person.getAttributes().getAttribute("day"));

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/PersonHealthMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/PersonHealthMCR.java
@@ -26,10 +26,10 @@ public class PersonHealthMCR implements PersonWithSchool, PersonHealth {
     private float[] weeklyTravelActivityHourOccupied = new float[24*7];
 
     //for exposure model
-    private Map<Mode, Float> weeklyMarginalMetHours = new HashMap<>();
+    private Map<Mode, Float> weeklyMarginalMetHours = new LinkedHashMap<>();
     private float weeklyMarginalMetHoursSport = 0.f;
-    private Map<String, Float> weeklyAccidentRisks = new HashMap<>();
-    private Map<String, float[]> weeklyExposureByPollutantByHour = new HashMap<>();
+    private Map<String, Float> weeklyAccidentRisks = new LinkedHashMap<>();
+    private Map<String, float[]> weeklyExposureByPollutantByHour = new LinkedHashMap<>();
     private Map<String, Float> weeklyExposureByPollutantNormalised;
 
     private float[] weeklyNoiseExposureByHour = new float[24*7];
@@ -42,9 +42,9 @@ public class PersonHealthMCR implements PersonWithSchool, PersonHealth {
 
     //for disease model
     private EnumMap<HealthExposures, EnumMap<Diseases, Float>> relativeRisksByDisease = new EnumMap<>(HealthExposures.class);
-    private Map<Integer, List<String>> healthDiseaseTracker = new HashMap<>();
+    private Map<Integer, List<String>> healthDiseaseTracker = new LinkedHashMap<>();
     private List<Diseases> currentDisease = new ArrayList<>();
-    private Map<Diseases, Float> currentDiseaseProb = new HashMap<>();
+    private Map<Diseases, Float> currentDiseaseProb = new LinkedHashMap<>();
 
 
     public PersonHealthMCR(int id, int age,

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/SportPAModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/SportPAModelMCR.java
@@ -17,7 +17,7 @@ import java.util.*;
 
 public class SportPAModelMCR extends AbstractModel implements ModelUpdateListener {
     private static final Logger logger = LogManager.getLogger(SportPAModelMCR.class);
-    private Map<String,Map<String,Double>> coef = new HashMap<>();
+    private Map<String,Map<String,Double>> coef = new LinkedHashMap<>();
 
     public SportPAModelMCR(DataContainer dataContainer, Properties properties, Random random) {
         super(dataContainer, properties, random);

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/diseaseModelOffline/HealthExposuresReader.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/diseaseModelOffline/HealthExposuresReader.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class HealthExposuresReader {
@@ -22,7 +23,7 @@ public class HealthExposuresReader {
     public Map<Integer, PersonHealth> readData(HealthDataContainerImpl dataContainer, String path) {
         logger.info("Reading person micro data with health exposures");
         PersonFactoryMCRHealth ppFactory = new PersonFactoryMCRHealth();
-        Map<Integer, PersonHealth> persons = new HashMap<>();
+        Map<Integer, PersonHealth> persons = new LinkedHashMap<>();
 
         String recString = "";
         int recCount = 0;
@@ -51,7 +52,7 @@ public class HealthExposuresReader {
                 pp.updateWeeklyMarginalMetHours(Mode.bicycle, Float.parseFloat(lineElements[posMmetCycle]));
                 pp.setWeeklyMarginalMetHoursSport(Float.parseFloat(lineElements[posMmetSport]));
 
-                Map<String, Float> exposureMap = new HashMap<>();
+                Map<String, Float> exposureMap = new LinkedHashMap<>();
                 exposureMap.put("pm2.5", Float.parseFloat(lineElements[posPM2_5]));
                 exposureMap.put("no2", Float.parseFloat(lineElements[posNO2]));
                 pp.setWeeklyExposureByPollutantNormalised(exposureMap);

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/models/BirthModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/models/BirthModelMCR.java
@@ -128,7 +128,7 @@ public class BirthModelMCR extends AbstractModel implements BirthModel {
         ((PersonHealthMCR)child).updateWeeklyMarginalMetHours(Mode.bicycle, 0.f);
         ((PersonHealthMCR)child).setWeeklyMarginalMetHoursSport(0.f);
 
-        Map<String, Float> exposureMap = new HashMap<>();
+        Map<String, Float> exposureMap = new LinkedHashMap<>();
         exposureMap.put("pm2.5", 0.f);
         exposureMap.put("no2", 0.f);
 

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMCRImpl.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMCRImpl.java
@@ -80,7 +80,7 @@ public class ConstructionOverwriteMCRImpl extends AbstractModel implements Const
 
         String fileName = properties.main.baseDirectory + properties.realEstate.constructionOverwriteDwellingFile;
         TableDataSet overwrite = SiloUtil.readCSVfile(fileName);
-        plannedDwellings = new HashMap<>();
+        plannedDwellings = new LinkedHashMap<>();
 
         for (int row = 1; row <= overwrite.getRowCount(); row++) {
             int year = (int) overwrite.getValueAt(row, "year");

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/models/MovesModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/models/MovesModelMCR.java
@@ -57,8 +57,8 @@ public class MovesModelMCR extends AbstractModel implements MovesModel {
 
     private final Map<HouseholdType, Double> averageHousingSatisfaction = new ConcurrentHashMap<>();
     private final Map<Integer, Double> satisfactionByHousehold = new ConcurrentHashMap<>();
-    private final Map<Integer, Integer> householdsByZone = new HashMap<>();
-    private final Map<Integer, Double > sumOfSatisfactionsByZone = new HashMap<>();
+    private final Map<Integer, Integer> householdsByZone = new LinkedHashMap<>();
+    private final Map<Integer, Double > sumOfSatisfactionsByZone = new LinkedHashMap<>();
     private YearByYearCsvModelTracker relocationTracker;
 
     public MovesModelMCR(DataContainer dataContainer, Properties properties, MovesStrategy movesStrategy,

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/data/HouseholdDataManagerMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/data/HouseholdDataManagerMstm.java
@@ -19,7 +19,7 @@ import static de.tum.bgu.msm.data.household.HouseholdUtil.getAnnualHhIncome;
 
 public class HouseholdDataManagerMstm implements HouseholdDataManager {
 
-    private final Map<Integer, Float> medianIncomeByMsa = new HashMap<>();
+    private final Map<Integer, Float> medianIncomeByMsa = new LinkedHashMap<>();
     private final HouseholdDataManagerImpl delegate;
     private final GeoData geoData;
     private final DwellingData dwellingData;
@@ -37,7 +37,7 @@ public class HouseholdDataManagerMstm implements HouseholdDataManager {
 
     private void calculateMedianHouseholdIncomeByMSA() {
 
-        Map<Integer, List<Integer>> incomesByMsa = new HashMap<>();
+        Map<Integer, List<Integer>> incomesByMsa = new LinkedHashMap<>();
         for (Household hh : delegate.getHouseholds()) {
             int zone = -1;
             Dwelling dwelling = dwellingData.getDwelling(hh.getDwellingId());

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/data/RealEstateDataManagerMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/data/RealEstateDataManagerMstm.java
@@ -30,7 +30,7 @@ public class RealEstateDataManagerMstm implements RealEstateDataManager {
     }
 
     private void calculateMedianRentByMSA() {
-        Map<Integer, ArrayList<Integer>> rentHashMap = new HashMap<>();
+        Map<Integer, ArrayList<Integer>> rentHashMap = new LinkedHashMap<>();
         for (Dwelling dd : delegate.getDwellings()) {
             int dwellingMSA = ((MstmZone) geoData.getZones().get(dd.getZoneId())).getMsa();
             if (rentHashMap.containsKey(dwellingMSA)) {

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/data/geo/GeoDataMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/data/geo/GeoDataMstm.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -16,7 +17,7 @@ public class GeoDataMstm extends DefaultGeoData {
 
     private final static Logger logger = LogManager.getLogger(GeoDataMstm.class);
 
-    private final Map<Integer, County> counties = new HashMap<>();
+    private final Map<Integer, County> counties = new LinkedHashMap<>();
 
     public GeoDataMstm() {
         super();

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/models/ConstructionOverwriteMstm.java
@@ -75,7 +75,7 @@ public class ConstructionOverwriteMstm extends AbstractModel implements Construc
 
         String fileName = properties.main.baseDirectory + properties.realEstate.constructionOverwriteDwellingFile;
         TableDataSet overwrite = SiloUtil.readCSVfile(fileName);
-        plannedDwellings = new HashMap<>();
+        plannedDwellings = new LinkedHashMap<>();
 
         for (int row = 1; row <= overwrite.getRowCount(); row++) {
             int year = (int) overwrite.getValueAt(row, "year");

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/models/MarriageModelMstm.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/models/MarriageModelMstm.java
@@ -183,7 +183,7 @@ public class MarriageModelMstm extends AbstractModel implements MarriageModel {
             return null;
         }
 
-        final Map<Person, Float> probabilities = new HashMap<>();
+        final Map<Person, Float> probabilities = new LinkedHashMap<>();
 
         Race personRace = ((PersonMstm) person).getRace();
         float sum = 0;
@@ -210,7 +210,7 @@ public class MarriageModelMstm extends AbstractModel implements MarriageModel {
         final Gender partnerGender = person.getGender().opposite();
         final boolean sameRace = random.nextDouble() >= interRacialMarriageShare;
 
-        final Map<Integer, Double> probabilityByAge = new HashMap<>();
+        final Map<Integer, Double> probabilityByAge = new LinkedHashMap<>();
 
         double sum = 0;
         for (int ageDiff : AGE_DIFF_RANGE) {

--- a/useCases/maryland/src/main/java/de/tum/bgu/msm/run/MstmMonitor.java
+++ b/useCases/maryland/src/main/java/de/tum/bgu/msm/run/MstmMonitor.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -91,13 +92,13 @@ public class MstmMonitor implements ResultsMonitor {
         // TOT: Total employment in zone
         for (Zone zone : geoData.getZones().values()) {
             int zoneId = zone.getZoneId();
-            int totalEmployment = jobsByTypeByZone.getOrDefault(zoneId, new HashMap<>()).values().stream().mapToInt(list -> list == null ? 0: list.size()).sum();
+            int totalEmployment = jobsByTypeByZone.getOrDefault(zoneId, new LinkedHashMap<>() ).values().stream().mapToInt( list -> list == null ? 0: list.size() ).sum();
 
             pw.println(zone.getZoneId() + "," + zone.getArea_sqmi() + "," + hhByZone.getOrDefault(zoneId, EMPTY_LIST).size() + ","
                     + enrollment.getIndexedValueAt(zoneId, "ENR") + ","
-                    + jobsByTypeByZone.getOrDefault(zoneId, new HashMap<>()).getOrDefault("RET",EMPTY_LIST).size() + "," +
-                    jobsByTypeByZone.getOrDefault(zoneId, new HashMap<>()).getOrDefault("OFF", EMPTY_LIST).size() + ","
-                    + jobsByTypeByZone.getOrDefault(zoneId, new HashMap<>()).getOrDefault("OTH", EMPTY_LIST).size() + ","
+                    + jobsByTypeByZone.getOrDefault(zoneId, new LinkedHashMap<>()).getOrDefault("RET",EMPTY_LIST).size() + "," +
+                    jobsByTypeByZone.getOrDefault(zoneId, new LinkedHashMap<>()).getOrDefault("OFF", EMPTY_LIST).size() + ","
+                    + jobsByTypeByZone.getOrDefault(zoneId, new LinkedHashMap<>()).getOrDefault("OTH", EMPTY_LIST).size() + ","
                     + totalEmployment);
         }
         pw.close();
@@ -135,8 +136,8 @@ public class MstmMonitor implements ResultsMonitor {
             for (int wrk = 0; wrk <= 3; wrk++) {
                 for (int inc = 1; inc <= 5; inc++) {
                     int size = householdsByIncomeByWorkersByZone
-                            .getOrDefault(zone.getZoneId(), new HashMap<>())
-                            .getOrDefault(wrk, new HashMap<>())
+                            .getOrDefault(zone.getZoneId(), new LinkedHashMap<>())
+                            .getOrDefault(wrk, new LinkedHashMap<>())
                             .getOrDefault(inc, EMPTY_LIST)
                             .size();
                     pwWrk.print("," + size);
@@ -183,8 +184,8 @@ public class MstmMonitor implements ResultsMonitor {
             for (int size = 1; size <= 5; size++) {
                 for (int inc = 1; inc <= 5; inc++) {
                     int count = householdsByIncomeBySizeByZone
-                            .getOrDefault(zone.getZoneId(), new HashMap<>())
-                            .getOrDefault(size, new HashMap<>())
+                            .getOrDefault(zone.getZoneId(), new LinkedHashMap<>())
+                            .getOrDefault(size, new LinkedHashMap<>())
                             .getOrDefault(inc, EMPTY_LIST)
                             .size();
                     pwSize.print("," + count);

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/data/job/JobFactoryMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/data/job/JobFactoryMuc.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -43,7 +44,7 @@ public class JobFactoryMuc implements JobFactory {
                     if (startTimeDistributionByJobType.containsKey(header[column])) {
                         startTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> startTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> startTimeDistribution = new LinkedHashMap<>();
                         startTimeDistribution.put(time, Double.parseDouble(row[column]));
                         startTimeDistributionByJobType.put(header[column], startTimeDistribution);
                     }
@@ -66,7 +67,7 @@ public class JobFactoryMuc implements JobFactory {
                     if (workingTimeDistributionByJobType.containsKey(header[column])) {
                         workingTimeDistributionByJobType.get(header[column]).put(time, Double.parseDouble(row[column]));
                     } else {
-                        Map<Integer, Double> workingTimeDistribution = new HashMap<>();
+                        Map<Integer, Double> workingTimeDistribution = new LinkedHashMap<>();
                         workingTimeDistribution.put(time, Double.parseDouble(row[column]));
                         workingTimeDistributionByJobType.put(header[column], workingTimeDistribution);
                     }

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/models/carOwnership/SwitchToAutonomousVehicleModelMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/models/carOwnership/SwitchToAutonomousVehicleModelMuc.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ public class SwitchToAutonomousVehicleModelMuc extends AbstractModel implements 
     /**
      * this variable stores a summary for print out purposes
      */
-    private Map<String, Integer> summary = new HashMap<>();
+    private Map<String, Integer> summary = new LinkedHashMap<>();
 
     public SwitchToAutonomousVehicleModelMuc(DataContainer dataContainer, Properties properties, InputStream inputStream, Random rnd) {
         super(dataContainer, properties, rnd);

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/av/ParkingSimpleMoceChoice.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/av/ParkingSimpleMoceChoice.java
@@ -19,10 +19,7 @@ import de.tum.bgu.msm.models.modeChoice.CommuteModeChoiceMapping;
 import de.tum.bgu.msm.properties.Properties;
 import org.matsim.api.core.v01.TransportMode;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
+import java.util.*;
 
 public class ParkingSimpleMoceChoice implements CommuteModeChoice {
     private final Properties properties;
@@ -64,7 +61,7 @@ public class ParkingSimpleMoceChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
         for (Person pp : household.getPersons().values()) {
@@ -97,7 +94,7 @@ public class ParkingSimpleMoceChoice implements CommuteModeChoice {
                     ptUtility = Math.exp(ptUtility);
                     carUtility = Math.exp(carUtility);
 
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, Math.pow(commutingTimeProbabilityCar, B_EXP_HOUSING_UTILITY));
                     utilityByMode.put(TransportMode.pt, Math.pow(commutingTimeProbabilityPt, B_EXP_HOUSING_UTILITY));
                     commuteModesByPerson.put(pp.getId(), utilityByMode);
@@ -142,7 +139,7 @@ public class ParkingSimpleMoceChoice implements CommuteModeChoice {
 
         CommuteModeChoiceMapping commuteModeChoiceMapping = new CommuteModeChoiceMapping(HouseholdUtil.getNumberOfWorkers(household));
 
-        Map<Integer, Map<String, Double>> commuteModesByPerson = new HashMap<>();
+        Map<Integer, Map<String, Double>> commuteModesByPerson = new LinkedHashMap<>();
         TreeMap<Double, Person> personByProbability = new TreeMap<>();
 
 
@@ -169,7 +166,7 @@ public class ParkingSimpleMoceChoice implements CommuteModeChoice {
                     LocationParkingData locationParkingData = (LocationParkingData) region.getAttributes().get("PARKING");
                     double penaltyDueToParking = 0.1 + 0.3 * locationParkingData.getParkingQuality();
                     carUtility = carUtility * penaltyDueToParking;
-                    Map<String, Double> utilityByMode = new HashMap<>();
+                    Map<String, Double> utilityByMode = new LinkedHashMap<>();
                     utilityByMode.put(TransportMode.car, Math.pow(commutingTimeProbabilityCar, B_EXP_HOUSING_UTILITY));
                     utilityByMode.put(TransportMode.pt, Math.pow(commutingTimeProbabilityPt, B_EXP_HOUSING_UTILITY));
                     commuteModesByPerson.put(pp.getId(), utilityByMode);

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/coreCityDevelopmentOnly/CoreCityJobMarketUpdate.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/coreCityDevelopmentOnly/CoreCityJobMarketUpdate.java
@@ -59,7 +59,7 @@ public class CoreCityJobMarketUpdate extends AbstractModel implements JobMarketU
             jobsByZone[jobTypeId][jj.getZoneId()]++;
         }
 
-        Map<String, List<Integer>> jobsAvailableForRemoval = new HashMap<>();
+        Map<String, List<Integer>> jobsAvailableForRemoval = new LinkedHashMap<>();
         for (Job jj : jobDataManager.getJobs()) {
             String token = jj.getType() + "." + jj.getZoneId() + "." + (jj.getWorkerId() == -1);
             if (jobsAvailableForRemoval.containsKey(token)) {

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/draconicResettlement/DraconicResettlementJobMarketUpdate.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/draconicResettlement/DraconicResettlementJobMarketUpdate.java
@@ -66,7 +66,7 @@ public class DraconicResettlementJobMarketUpdate extends AbstractModel implement
         logger.info("  Updating job market based on exogenous forecast for " + year + " (multi-threaded step)");
 
 
-        Map<String, List<Integer>> jobsAvailableForRemoval = new HashMap<>();
+        Map<String, List<Integer>> jobsAvailableForRemoval = new LinkedHashMap<>();
         for (Job jj : jobDataManager.getJobs()) {
             String token = jj.getType() + "." + jj.getZoneId() + "." + (jj.getWorkerId() == -1);
             if (jobsAvailableForRemoval.containsKey(token)) {

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/ev/EVResultMonitor.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/ev/EVResultMonitor.java
@@ -52,7 +52,7 @@ public class EVResultMonitor implements ResultsMonitor {
         int nAutos = 0;
         int nEVs = 0;
 
-        Map<Integer, ZonalAttributes> dataByZone = new HashMap<>();
+        Map<Integer, ZonalAttributes> dataByZone = new LinkedHashMap<>();
 
         for (Household hh : dataContainer.getHouseholdDataManager().getHouseholds()) {
 

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/ev/SwitchToElectricVehicleModelMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/ev/SwitchToElectricVehicleModelMuc.java
@@ -30,7 +30,7 @@ public class SwitchToElectricVehicleModelMuc extends AbstractModel implements Mo
     /**
      * this variable stores a summary for print out purposes
      */
-    private Map<String, Integer> summary = new HashMap<>();
+    private Map<String, Integer> summary = new LinkedHashMap<>();
 
     public SwitchToElectricVehicleModelMuc(DataContainer dataContainer, Properties properties, Random rnd) {
         super(dataContainer, properties, rnd);

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthDataContainerImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthDataContainerImpl.java
@@ -32,7 +32,7 @@ public class HealthDataContainerImpl implements DataContainerWithSchools, DataCo
 
     private final DataContainerWithSchools delegate;
     private final Properties properties;
-    private Map<Id<Link>, LinkInfo> linkInfo = new HashMap<>();
+    private Map<Id<Link>, LinkInfo> linkInfo = new LinkedHashMap<>();
     private Set<Pollutant> pollutantSet = new HashSet<>();
     private EnumMap<Mode, EnumMap<MitoGender,Map<Integer,Double>>> avgSpeeds;
 

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthModelMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthModelMuc.java
@@ -76,7 +76,7 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
                 scenario = ScenarioUtils.createMutableScenario(initialMatsimConfig);
                 String networkFile = properties.main.baseDirectory + "/" + scenario.getConfig().network().getInputFile();
                 new MatsimNetworkReader(scenario.getNetwork()).readFile(networkFile);
-                Map<Id<Link>, LinkInfo> linkInfoMap = new HashMap<>();
+                Map<Id<Link>, LinkInfo> linkInfoMap = new LinkedHashMap<>();
                 for(Link link : scenario.getNetwork().getLinks().values()){
                     linkInfoMap.put(link.getId(), new LinkInfo(link.getId()));
                 }
@@ -114,7 +114,7 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
                 scenario = ScenarioUtils.createMutableScenario(initialMatsimConfig);
                 String networkFile = properties.main.baseDirectory + "/" + scenario.getConfig().network().getInputFile();
                 new MatsimNetworkReader(scenario.getNetwork()).readFile(networkFile);
-                Map<Id<Link>, LinkInfo> linkInfoMap = new HashMap<>();
+                Map<Id<Link>, LinkInfo> linkInfoMap = new LinkedHashMap<>();
                 for(Link link : scenario.getNetwork().getLinks().values()){
                     linkInfoMap.put(link.getId(), new LinkInfo(link.getId()));
                 }
@@ -352,12 +352,12 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
             pathExposureNo2 += linkExposureNo2;
         }
 
-        Map<String, Float> accidentRiskMap = new HashMap<>();
+        Map<String, Float> accidentRiskMap = new LinkedHashMap<>();
         //accidentRiskMap.put("lightInjury", pathLightInjuryRisk);
         accidentRiskMap.put("severeInjury", (float) pathSevereInjuryRisk);
         accidentRiskMap.put("fatality", (float) pathFatalityRisk);
 
-        Map<String, Float> exposureMap = new HashMap<>();
+        Map<String, Float> exposureMap = new LinkedHashMap<>();
         exposureMap.put("pm2.5", (float) pathExposurePm25);
         exposureMap.put("no2", (float) pathExposureNo2);
 
@@ -380,7 +380,7 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
         }
 
         // todo: consider location-specific exposures & occupation-specific METs for work activities
-        Map<String, Float> exposureMap = new HashMap<>();
+        Map<String, Float> exposureMap = new LinkedHashMap<>();
         exposureMap.put("pm2.5", (float) PollutionExposure.getActivityExposurePm25(activityDuration));
         exposureMap.put("no2", (float) PollutionExposure.getActivityExposureNo2(activityDuration));
 
@@ -473,7 +473,7 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
         for(Person person : dataContainer.getHouseholdDataManager().getPersons()) {
             double minutesAtHome = Math.max(0., 10080. - (((PersonHealth) person).getWeeklyTravelSeconds() / 60.) - (((PersonHealth) person).getWeeklyActivityMinutes()));
 
-            Map<String, Float> exposureMap = new HashMap<>();
+            Map<String, Float> exposureMap = new LinkedHashMap<>();
             exposureMap.put("pm2.5", (float) PollutionExposure.getHomeExposurePm25(minutesAtHome));
             exposureMap.put("no2", (float) PollutionExposure.getHomeExposureNo2(minutesAtHome));
 

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/PersonHealthMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/PersonHealthMuc.java
@@ -25,9 +25,9 @@ public class PersonHealthMuc implements PersonWithSchool, PersonHealth {
     private float weeklyHomeMinutes = 0.f;
 
     //for health model
-    private Map<Mode, Float> weeklyMarginalMetHours = new HashMap<>();
-    private Map<String, Float> weeklyAccidentRisks = new HashMap<>();
-    private Map<String, Float> weeklyExposureByPollutant = new HashMap<>();
+    private Map<Mode, Float> weeklyMarginalMetHours = new LinkedHashMap<>();
+    private Map<String, Float> weeklyAccidentRisks = new LinkedHashMap<>();
+    private Map<String, Float> weeklyExposureByPollutant = new LinkedHashMap<>();
     private Map<String, Float> relativeRisks;
     private float allCauseRR;
 


### PR DESCRIPTION
I had repaired the tests in RunFabilandTest so that they deterministically passed on my local machine.  However, on the build server they failed.  Inspection of the output revealed that, in the matsim plans that came from silo and entered in the year one matsim simulation, some of the persons had other home location coordinates.  Presumably, the `Moves` model was not deterministic in the sense that it produced different results on different machines.  I did the following:
1. change all HashMap to LinkedHashMap to make iterations over the containers independent from hardware.  This did not fix my issue, but I think that it is in general useful.
2. remove the multi-threading in MovesModelImpl.  THIS ACTUALLY FIXED THE PROBLEM, i.e. the Moves model now returns the same result on the build server as on my local machine.  The multi-threading in that method was not dependent on some separate config parameter, but was programmed as a side-effect of `TransportModelPropertiesModule.TravelTimeImplIdentifier.MATSIM`.  I thus switched off the multi-threading completely in that class; if someone wants to be able to switch it on by a separate parameter, please go ahead and add the corresponding code.
3. I am also trying to reduce non-final static variables, since they are known to cause such problems.  Either make them non-static (i.e. instance variables) if possible, or try to make them final.